### PR TITLE
add all/active endpoints in bamboo

### DIFF
--- a/internal/bamboohr/employees_test.go
+++ b/internal/bamboohr/employees_test.go
@@ -34,11 +34,9 @@ func TestAPI(t *testing.T) {
 			BaseURL:   base.ResolveReference(&url.URL{Path: "/api/gateway.php/"}),
 			Subdomain: "test",
 		},
-		CurrentOnly: false,
-		Fields:      []string{"id"},
 	}
 	client := server.NewDebugClient(http.DefaultClient, zerolog.New(os.Stdout))
-	_, err = bamboohr.GetEmployees(ctx, client, req)
+	_, err = bamboohr.GetAllEmployees(ctx, client, req)
 	require.NoError(t, err, "get employees")
 }
 

--- a/internal/bamboohr/ooo.go
+++ b/internal/bamboohr/ooo.go
@@ -1,0 +1,158 @@
+package bamboohr
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/pomerium/datasource/internal/util"
+)
+
+type WhoIsOutRequest struct {
+	Auth
+	// Location is required as BambooHR only returns date, and it must be converted into timestamp
+	// Timezone is an installation specific setting that does not seem to be available via API
+	// but may only be accessed from the BambooHR Admin UI
+	Location   *time.Location
+	Start, End time.Time
+}
+
+const BambooDateLayout = "2006-01-02"
+
+func (req WhoIsOutRequest) RequestURL() *url.URL {
+	u := req.Auth.RequestURL("v1/time_off/whos_out")
+
+	vals := make(url.Values)
+	vals.Add("start", req.Start.Format(BambooDateLayout))
+	vals.Add("end", req.End.Format(BambooDateLayout))
+	u.RawQuery = vals.Encode()
+
+	return u
+}
+
+// GetAvailableEmployees only returns employees that are marked as active
+// and are not on vacation or absense leave
+func GetAvailableEmployees(ctx context.Context, client *http.Client, param EmployeeRequest) ([]Employee, error) {
+	employees, err := GetAllEmployees(ctx, client, param)
+	if err != nil {
+		return nil, fmt.Errorf("get employees: %w", err)
+	}
+
+	ooo, err := WhoIsOut(ctx, client, WhoIsOutRequest{
+		Auth:     param.Auth,
+		Location: param.Location,
+		Start:    time.Now(),
+		End:      time.Now().Add(time.Hour * 24),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("who is out: %w", err)
+	}
+
+	return filterOOO(employees, ooo), nil
+}
+
+// WhoIsOut retrieves list of employees who are currently marked as out
+func WhoIsOut(ctx context.Context, client *http.Client, param WhoIsOutRequest) (map[string][]Period, error) {
+	u := param.RequestURL()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Add("accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request: %w", err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %v: unexpected return status: %s", u, resp.Status)
+	}
+
+	p, err := parseWhoIsOutResponse(resp.Body, param.Location)
+	if err != nil {
+		return nil, fmt.Errorf("who is out response: %w", err)
+	}
+	return p, nil
+}
+
+type Period struct {
+	Start time.Time
+	End   time.Time
+}
+
+// returns map of employeeID to period when one is out
+func parseWhoIsOutResponse(r io.Reader, location *time.Location) (map[string][]Period, error) {
+	var objs []map[string]interface{}
+	if err := json.NewDecoder(r).Decode(&objs); err != nil {
+		return nil, fmt.Errorf("decode json: %w", err)
+	}
+
+	dst := make([]struct {
+		Type       string        `json:"type" mapstructure:"time"`
+		EmployeeID json.Number   `json:"employeeId" mapstructure:"employeeId"`
+		Start      util.DateTime `json:"start" mapstructure:"start"`
+		End        util.DateTime `json:"end" mapstructure:"end"`
+	}, 0, len(objs))
+	dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			util.DateTimeDecodeHook(BambooDateLayout, location),
+			util.JSONNumberDecodeHook,
+		),
+		Result: &dst,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("mapstructure decoder: %w", err)
+	}
+
+	if err = dec.Decode(objs); err != nil {
+		return nil, fmt.Errorf("mapstructure decode: %w", err)
+	}
+
+	out := make(map[string][]Period)
+	for _, rec := range dst {
+		id := string(rec.EmployeeID)
+		if id == "" {
+			// some other period kind that is not employee specific,
+			// and cannot be resolved
+			continue
+		}
+		out[id] = append(out[id], Period{
+			Start: rec.Start.Time(),
+			End:   rec.End.Time().Add(time.Hour * 24),
+		})
+	}
+
+	return out, nil
+}
+
+func isOut(now time.Time, out []Period) bool {
+	for _, p := range out {
+		if now.After(p.Start) && now.Before(p.End) {
+			return true
+		}
+	}
+	return false
+}
+
+func filterOOO(src []Employee, ooo map[string][]Period) []Employee {
+	dst := make([]Employee, 0, len(src))
+	now := time.Now()
+	for _, emp := range src {
+		if !isOut(now, ooo[emp.ID.String()]) {
+			dst = append(dst, emp)
+		}
+	}
+
+	return dst
+}

--- a/internal/bamboohr/ooo_test.go
+++ b/internal/bamboohr/ooo_test.go
@@ -1,0 +1,26 @@
+package bamboohr
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOOO(t *testing.T) {
+	now := time.Now()
+	for _, tc := range []struct {
+		name string
+		ooo  bool
+		out  []Period
+	}{
+		{"empty", false, nil},
+		{"simple", true, []Period{
+			{Start: now.Add(-time.Second), End: now.Add(time.Second)},
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.ooo, isOut(now, tc.out))
+		})
+	}
+}

--- a/internal/bamboohr/testdata/employees-company-test.json
+++ b/internal/bamboohr/testdata/employees-company-test.json
@@ -1,27 +1,38 @@
 {
-  "title": "This is my report",
+  "title": "Report",
   "fields": [
-    {
-      "id": "firstName",
-      "type": "text",
-      "name": "First Name"
-    },
-    {
-      "id": "lastName",
-      "type": "text",
-      "name": "Last Name"
-    },
-    {
-      "id": "91",
-      "type": "employee",
-      "name": "Supervisor"
-    }
+    { "id": "firstName" },
+    { "id": "lastName" },
+    { "id": "workEmail" },
+    { "id": "department" },
+    { "id": "division" },
+    { "id": "country" },
+    { "id": "state" },
+    { "id": "status" },
+    { "id": "id" }
   ],
   "employees": [
     {
+      "id": "1",
       "firstName": "John",
       "lastName": "Doe",
-      "91": "Jane Doe"
+      "workEmail": "john.doe@corp.com",
+      "department": "Human Resources",
+      "division": "HR",
+      "country": "USA",
+      "state": "CA",
+      "status": "Active"
+    },
+    {
+      "id": "2",
+      "firstName": "Jane",
+      "lastName": "Doe",
+      "workEmail": "jane.doe@corp.com",
+      "department": "Human Resources",
+      "division": "HR",
+      "country": "USA",
+      "state": "CA",
+      "status": "Active"
     }
   ]
 }

--- a/internal/bamboohr/testdata/who-is-out.json
+++ b/internal/bamboohr/testdata/who-is-out.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": 2,
+    "type": "timeOff",
+    "employeeId": 12,
+    "name": "Jane Doe",
+    "start": "2022-04-20",
+    "end": "2022-04-21"
+  }
+]

--- a/internal/util/mapstructure.go
+++ b/internal/util/mapstructure.go
@@ -1,0 +1,91 @@
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"reflect"
+	"time"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+// DateTime is used by some API services to represent date and/or time
+// in a non-standard manners, that may also be
+type DateTime struct {
+	tm     time.Time
+	layout string
+}
+
+func (d *DateTime) Time() time.Time {
+	return d.tm
+}
+
+var (
+	_              = json.Marshaler(new(DateTime))
+	DateType       = reflect.TypeOf(DateTime{})
+	JSONNumberType = reflect.TypeOf(json.Number(""))
+)
+
+// MarshalJSON implements json.Marshaler
+func (d DateTime) MarshalJSON() ([]byte, error) {
+	if d.tm.IsZero() {
+		return []byte("null"), nil
+	}
+
+	return json.Marshal(d.tm.Format(d.layout))
+}
+
+// DateTimeDecodeHook parses date time that's supplied in a non-standard layout
+// if layout does not contain a time zone, a location need be provided
+func DateTimeDecodeHook(layout string, location *time.Location) mapstructure.DecodeHookFuncType {
+	return func(srcT, dstT reflect.Type, data interface{}) (interface{}, error) {
+		if dstT != DateType {
+			return data, nil
+		}
+
+		if data == nil {
+			return nil, nil
+		}
+
+		txt, ok := data.(string)
+		if !ok {
+			return data, nil
+		}
+
+		var tm time.Time
+		var err error
+		if location == nil {
+			tm, err = time.Parse(layout, txt)
+		} else {
+			tm, err = time.ParseInLocation(layout, txt, location)
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		return &DateTime{tm, layout}, nil
+	}
+}
+
+// JSONNumberDecodeHook helps mapstructure to deal with
+func JSONNumberDecodeHook(srcT, dstT reflect.Type, data interface{}) (interface{}, error) {
+	if dstT != JSONNumberType {
+		return data, nil
+	}
+
+	switch val := data.(type) {
+	case string:
+		return val, nil
+	case float64:
+		if x := math.Trunc(val); x != val {
+			return nil, fmt.Errorf("JSON number must be represented as a whole number, got %f", val)
+		} else {
+			return fmt.Sprint(int(x)), nil
+		}
+	case int64:
+		return fmt.Sprint(val), nil
+	default:
+		return nil, fmt.Errorf("unsupported format %v", val)
+	}
+}

--- a/internal/util/mapstructure_test.go
+++ b/internal/util/mapstructure_test.go
@@ -1,0 +1,52 @@
+package util_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/pomerium/datasource/internal/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDate(t *testing.T) {
+	est, err := time.LoadLocation("EST")
+	assert.NoError(t, err, "load EST timezone")
+
+	for _, tc := range []struct {
+		json     string
+		layout   string
+		location string
+		expect   time.Time
+	}{
+		{`{"date":"2022-04-21"}`, "2006-01-02", "EST", time.Date(2022, 4, 21, 0, 0, 0, 0, est)},
+		{`{"date":"2022-04-21"}`, "2006-01-02", "UTC", time.Date(2022, 4, 21, 0, 0, 0, 0, time.UTC)},
+		{`{"date":null}`, "2006-01-02", "EST", time.Time{}},
+	} {
+		t.Run(tc.json, func(t *testing.T) {
+			var v struct {
+				Date util.DateTime `json:"date" mapstructure:"date"`
+			}
+			location, err := time.LoadLocation(tc.location)
+			require.NoError(t, err)
+
+			dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+				DecodeHook: util.DateTimeDecodeHook(tc.layout, location),
+				Result:     &v,
+			})
+			require.NoError(t, err)
+
+			m := make(map[string]interface{})
+			require.NoError(t, json.Unmarshal([]byte(tc.json), &m))
+			require.NoError(t, dec.Decode(m))
+
+			assert.Equal(t, tc.expect, v.Date.Time())
+
+			data, err := json.Marshal(v)
+			require.NoError(t, err)
+			assert.Equal(t, tc.json, string(data))
+		})
+	}
+}

--- a/internal/util/tags.go
+++ b/internal/util/tags.go
@@ -1,0 +1,25 @@
+package util
+
+import (
+	"reflect"
+	"strings"
+)
+
+// GetStructTags returns list of names for a given struct tag
+func GetStructTagNames(val any, tag string) []string {
+	fields := reflect.VisibleFields(reflect.Indirect(reflect.ValueOf(val)).Type())
+	names := make([]string, 0, len(fields))
+
+	for _, field := range fields {
+		name, there := field.Tag.Lookup(tag)
+		if !there {
+			continue
+		}
+		split := strings.Split(name, ",")
+		if split[0] != "" && split[0] != "-" {
+			names = append(names, split[0])
+		}
+	}
+
+	return names
+}

--- a/internal/util/tags_test.go
+++ b/internal/util/tags_test.go
@@ -1,0 +1,37 @@
+package util_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pomerium/datasource/internal/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTags(t *testing.T) {
+	for _, tc := range []struct {
+		in   any
+		tags []string
+	}{
+		{
+			struct{}{},
+			[]string{},
+		},
+		{
+			struct {
+				A string `json:"xx" tag:"one"`
+				B string `tag:"two"`
+				C string `json:"three"`
+				D string `json:"dd" tag:",omitempty"`
+				E string `json:"ee" tag:"four,omitempty"`
+				F string `tag:"-,omitempty"`
+				G string `tag:"-"`
+			}{},
+			[]string{"one", "two", "four"},
+		},
+	} {
+		t.Run(strings.Join(tc.tags, ","), func(t *testing.T) {
+			assert.Equal(t, tc.tags, util.GetStructTagNames(tc.in, "tag"))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Split into `/employees/all` that returns all active employees, and `/employees/available` that would only return employees that are not on leave at the moment.
Note that as BambooHR returns dates for the out of office periods, it is important to set the time zone correctly via `--bamboohr-time-zone` parameter.

## Related issues

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
