### PR TITLE
ip2location: add ip2location geoip source

### DIFF
--- a/cmd/pomerium-datasource/ip2location.go
+++ b/cmd/pomerium-datasource/ip2location.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+
+	"github.com/pomerium/datasource/internal/ip2location"
+	"github.com/pomerium/datasource/internal/server"
+)
+
+var ip2LocationArgs struct {
+	address string
+	file    string
+}
+
+var ip2LocationCmd = &cobra.Command{
+	Use:   "ip2location <file>",
+	Short: "runs the IP2Location server",
+	Args:  cobra.ExactArgs(1),
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return fmt.Errorf("file is required")
+		}
+		ip2LocationArgs.file = args[0]
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		srv := ip2location.NewServer(ip2location.WithFile(ip2LocationArgs.file))
+		err := server.RunHTTPServer(cmd.Context(), ip2LocationArgs.address, srv)
+		if err != nil {
+			log.Fatal().Err(err).Send()
+		}
+	},
+}
+
+func init() {
+	ip2LocationCmd.Flags().StringVar(&ip2LocationArgs.address, "address", "localhost:8080",
+		"the tcp address to listen on")
+}

--- a/cmd/pomerium-datasource/main.go
+++ b/cmd/pomerium-datasource/main.go
@@ -8,26 +8,29 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
 	"github.com/pomerium/datasource/internal"
 )
 
 func main() {
-	log := makeLogger()
+	logger := makeLogger()
 
 	rootCmd := &cobra.Command{
 		Use:     "pomerium-datasource",
 		Version: internal.FullVersion(),
 	}
-	rootCmd.AddCommand(bambooCommand(log), zenefitsCommand(log))
-	if err := rootCmd.ExecuteContext(signalContext(log)); err != nil {
-		log.Fatal().Err(err).Msg("exit")
+	rootCmd.AddCommand(bambooCommand(logger), zenefitsCommand(logger), ip2LocationCmd)
+	if err := rootCmd.ExecuteContext(signalContext(logger)); err != nil {
+		logger.Fatal().Err(err).Msg("exit")
 	}
 }
 
 func makeLogger() zerolog.Logger {
-	return zerolog.New(zerolog.NewConsoleWriter())
+	logger := zerolog.New(zerolog.NewConsoleWriter())
+	log.Logger = logger
+	return logger
 }
 
 func signalContext(log zerolog.Logger) context.Context {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/client9/misspell v0.3.4
+	github.com/gabriel-vasile/mimetype v1.4.0
 	github.com/go-playground/validator/v10 v10.10.1
 	github.com/golangci/golangci-lint v1.45.2
 	github.com/gorilla/mux v1.8.0
@@ -151,6 +152,7 @@ require (
 	gitlab.com/bosi/decorder v0.2.1 // indirect
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
+	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220209214540-3681064d5158 // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -180,6 +180,8 @@ github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5
 github.com/fullstorydev/grpcurl v1.6.0/go.mod h1:ZQ+ayqbKMJNhzLmbpCiurTVlaK2M/3nqZCxaQ2Ze/sM=
 github.com/fzipp/gocyclo v0.4.0 h1:IykTnjwh2YLyYkGa0y92iTTEQcnyAz0r9zOo15EbJ7k=
 github.com/fzipp/gocyclo v0.4.0/go.mod h1:rXPyn8fnlpa0R2csP/31uerbiVBugk5whMdlyaLkLoA=
+github.com/gabriel-vasile/mimetype v1.4.0 h1:Cn9dkdYsMIu56tGho+fqzh7XmvY2YyGU0FnbhiOsEro=
+github.com/gabriel-vasile/mimetype v1.4.0/go.mod h1:fA8fi6KUiG7MgQQ+mEWotXoEOvmxRtOJlERCzSmRvr8=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-critic/go-critic v0.6.2 h1:L5SDut1N4ZfsWZY0sH4DCrsHLHnhuuWak2wa165t9gs=
 github.com/go-critic/go-critic v0.6.2/go.mod h1:td1s27kfmLpe5G/DPjlnFI7o1UCzePptwU7Az0V5iCM=
@@ -888,6 +890,7 @@ golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLd
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210505024714-0287a6fb4125/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 h1:CIJ76btIcR3eFI5EgSo6k1qKw9KJexJuRLI9G7Hp5wE=

--- a/internal/ip2location/ip2location.go
+++ b/internal/ip2location/ip2location.go
@@ -1,0 +1,132 @@
+package ip2location
+
+import (
+	"archive/zip"
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gabriel-vasile/mimetype"
+
+	"github.com/pomerium/datasource/internal/jsonutil"
+	"github.com/pomerium/datasource/internal/netutil"
+)
+
+func fileToJSON(dst *jsonutil.JSONArrayStream, fileName string) (err error) {
+	f, err := os.Open(fileName)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		return err
+	}
+
+	mt, err := mimetype.DetectReader(f)
+	if err != nil {
+		return err
+	}
+	_, err = f.Seek(0, os.SEEK_SET)
+	if err != nil {
+		return err
+	}
+
+	if mt.Is("application/zip") {
+		zr, err := zip.NewReader(f, fi.Size())
+		if err != nil {
+			return err
+		}
+		return zipToJSON(dst, zr)
+	}
+
+	return csvToJSON(dst, f)
+}
+
+func zipToJSON(dst *jsonutil.JSONArrayStream, zr *zip.Reader) (err error) {
+	for _, zf := range zr.File {
+		if filepath.Ext(strings.ToLower(zf.Name)) == ".csv" {
+			rc, err := zf.Open()
+			if err != nil {
+				return err
+			}
+			defer rc.Close()
+
+			return csvToJSON(dst, rc)
+		}
+	}
+	return fmt.Errorf("no csv file found in zip file")
+}
+
+func csvToJSON(dst *jsonutil.JSONArrayStream, r io.Reader) error {
+	cr := csv.NewReader(r)
+	for {
+		row, err := cr.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		} else if err != nil {
+			return err
+		}
+
+		err = csvRowToJSON(dst, row)
+		if err != nil {
+			return err
+		}
+	}
+	return dst.Close()
+}
+
+// parseCSVRow parses an individual row of the  CSV file.
+func csvRowToJSON(dst *jsonutil.JSONArrayStream, row []string) (err error) {
+	if len(row) < 2 {
+		return nil
+	}
+
+	start, err := netutil.ParseIPNumber(row[0])
+	if err != nil {
+		return err
+	}
+
+	end, err := netutil.ParseIPNumber(row[1])
+	if err != nil {
+		return err
+	}
+
+	cidrs := netutil.AddrRangeToPrefixes(start, end)
+	for _, cidr := range cidrs {
+		var record Record
+		record.Index.CIDR = cidr.String()
+		record.ID = cidr.String()
+		if len(row) >= 3 {
+			record.Country = row[2]
+		}
+		if len(row) >= 5 {
+			record.State = row[4]
+		}
+		if len(row) >= 6 {
+			record.City = row[5]
+		}
+		if len(row) >= 8 {
+			record.Zip = row[8]
+		}
+		if len(row) >= 9 {
+			record.Timezone = row[9]
+		}
+		// ignore rows not associated with a country
+		if record.Country == "" || record.Country == "-" {
+			continue
+		}
+
+		err = dst.Encode(record)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/ip2location/ip2location_test.go
+++ b/internal/ip2location/ip2location_test.go
@@ -1,0 +1,518 @@
+package ip2location
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/datasource/internal/jsonutil"
+)
+
+// Data comes from the free IP2Location LITE database. Attribution:
+//   This site or product includes IP2Location LITE data available from
+//   <a href="https://lite.ip2location.com">https://lite.ip2location.com</a>.
+
+const sampleIP2LocationData = `
+"0","281470681743359","-","-","-","-","0.000000","0.000000","-","-"
+"281470681743360","281470698520575","-","-","-","-","0.000000","0.000000","-","-"
+"281470698520576","281470698520831","US","United States of America","California","Los Angeles","34.052230","-118.243680","90001","-07:00"
+"281470698520832","281470698521599","CN","China","Fujian","Fuzhou","26.061390","119.306110","350004","+08:00"
+"281470698521600","281470698522623","AU","Australia","Victoria","Melbourne","-37.814000","144.963320","3000","+11:00"
+"281470698522624","281470698524671","CN","China","Guangdong","Guangzhou","23.116670","113.250000","510140","+08:00"
+"281470698524672","281470698528767","JP","Japan","Tokyo","Tokyo","35.689506","139.691700","160-0021","+09:00"
+"281470698528768","281470698536959","CN","China","Guangdong","Guangzhou","23.116670","113.250000","510140","+08:00"
+"281470698536960","281470698537983","JP","Japan","Hiroshima","Hiroshima","34.385280","132.455280","732-0057","+09:00"
+"281470698537984","281470698538239","JP","Japan","Miyagi","Sendai","38.267000","140.867000","980-0802","+09:00"
+"281470698538240","281470698541055","JP","Japan","Hiroshima","Hiroshima","34.385280","132.455280","732-0057","+09:00"
+"281470698541056","281470698541311","JP","Japan","Shimane","Matsue","35.467000","133.050000","690-0015","+09:00"
+"281470698541312","281470698541567","JP","Japan","Yamaguchi","Hikari","33.961940","131.942220","743-0021","+09:00"
+"281470698541568","281470698541823","JP","Japan","Tottori","Yonago","35.433000","133.333000","683-0846","+09:00"
+"281470698541824","281470698542079","JP","Japan","Tottori","Kurayoshi","35.433000","133.817000","682-0021","+09:00"
+"281470698542080","281470698542335","JP","Japan","Tottori","Tottori","35.500000","134.233000","680-0805","+09:00"
+"281470698542336","281470698542591","JP","Japan","Shimane","Matsue","35.467000","133.050000","690-0015","+09:00"
+"281470698542592","281470698542847","JP","Japan","Okayama","Okayama","34.650000","133.917000","700-0824","+09:00"
+"281470698542848","281470698543103","JP","Japan","Yamaguchi","Yamaguchi","34.183000","131.467000","754-0893","+09:00"
+"281470698543104","281470698543359","JP","Japan","Shimane","Izumo","35.367000","132.767000","693-0044","+09:00"
+"281470698543360","281470698543615","JP","Japan","Tottori","Kurayoshi","35.433000","133.817000","682-0021","+09:00"
+"281470698543616","281470698543871","JP","Japan","Tottori","Tottori","35.500000","134.233000","680-0805","+09:00"
+"281470698543872","281470698544127","JP","Japan","Shimane","Izumo","35.367000","132.767000","693-0044","+09:00"
+"281470698544128","281470698544383","JP","Japan","Yamaguchi","Hikari","33.961940","131.942220","743-0021","+09:00"
+"281470698544384","281470698544639","JP","Japan","Hiroshima","Hiroshima","34.385280","132.455280","732-0057","+09:00"
+"281470698544640","281470698544895","JP","Japan","Tottori","Yonago","35.433000","133.333000","683-0846","+09:00"
+"281470698544896","281470698545151","JP","Japan","Tottori","Kurayoshi","35.433000","133.817000","682-0021","+09:00"
+"281470698545152","281470698545407","JP","Japan","Yamaguchi","Hikari","33.961940","131.942220","743-0021","+09:00"
+"281470698545408","281470698545663","JP","Japan","Shimane","Izumo","35.367000","132.767000","693-0044","+09:00"
+"281470698545664","281470698546175","JP","Japan","Yamaguchi","Yamaguchi","34.183000","131.467000","754-0893","+09:00"
+"281470698546176","281470698546431","JP","Japan","Shimane","Izumo","35.367000","132.767000","693-0044","+09:00"
+"281470698546432","281470698546687","JP","Japan","Shimane","Matsue","35.467000","133.050000","690-0015","+09:00"
+"281470698546688","281470698547199","JP","Japan","Yamaguchi","Yamaguchi","34.183000","131.467000","754-0893","+09:00"
+"281470698547200","281470698547455","JP","Japan","Yamaguchi","Hikari","33.961940","131.942220","743-0021","+09:00"
+"281470698547456","281470698547711","JP","Japan","Shimane","Matsue","35.467000","133.050000","690-0015","+09:00"
+"281470698547712","281470698547967","JP","Japan","Tottori","Tottori","35.500000","134.233000","680-0805","+09:00"
+"281470698547968","281470698548223","JP","Japan","Yamaguchi","Yamaguchi","34.183000","131.467000","754-0893","+09:00"
+"281470698548224","281470698548479","JP","Japan","Okayama","Okayama","34.650000","133.917000","700-0824","+09:00"
+"281470698548480","281470698548735","JP","Japan","Hiroshima","Hiroshima","34.385280","132.455280","732-0057","+09:00"
+"281470698548736","281470698548991","JP","Japan","Shimane","Izumo","35.367000","132.767000","693-0044","+09:00"
+`
+
+func TestParseCSV(t *testing.T) {
+	var buf bytes.Buffer
+	err := csvToJSON(jsonutil.NewJSONArrayStream(&buf), strings.NewReader(sampleIP2LocationData))
+	require.NoError(t, err)
+	assert.JSONEq(t, `[
+  {
+    "$index": {
+      "cidr": "1.0.0.0/24"
+    },
+    "id": "1.0.0.0/24",
+    "country": "US",
+    "state": "California",
+    "city": "Los Angeles",
+    "zip": "90001",
+    "timezone": "-07:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.1.0/24"
+    },
+    "id": "1.0.1.0/24",
+    "country": "CN",
+    "state": "Fujian",
+    "city": "Fuzhou",
+    "zip": "350004",
+    "timezone": "+08:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.2.0/23"
+    },
+    "id": "1.0.2.0/23",
+    "country": "CN",
+    "state": "Fujian",
+    "city": "Fuzhou",
+    "zip": "350004",
+    "timezone": "+08:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.4.0/22"
+    },
+    "id": "1.0.4.0/22",
+    "country": "AU",
+    "state": "Victoria",
+    "city": "Melbourne",
+    "zip": "3000",
+    "timezone": "+11:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.8.0/21"
+    },
+    "id": "1.0.8.0/21",
+    "country": "CN",
+    "state": "Guangdong",
+    "city": "Guangzhou",
+    "zip": "510140",
+    "timezone": "+08:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.16.0/20"
+    },
+    "id": "1.0.16.0/20",
+    "country": "JP",
+    "state": "Tokyo",
+    "city": "Tokyo",
+    "zip": "160-0021",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.32.0/19"
+    },
+    "id": "1.0.32.0/19",
+    "country": "CN",
+    "state": "Guangdong",
+    "city": "Guangzhou",
+    "zip": "510140",
+    "timezone": "+08:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.64.0/22"
+    },
+    "id": "1.0.64.0/22",
+    "country": "JP",
+    "state": "Hiroshima",
+    "city": "Hiroshima",
+    "zip": "732-0057",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.68.0/24"
+    },
+    "id": "1.0.68.0/24",
+    "country": "JP",
+    "state": "Miyagi",
+    "city": "Sendai",
+    "zip": "980-0802",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.69.0/24"
+    },
+    "id": "1.0.69.0/24",
+    "country": "JP",
+    "state": "Hiroshima",
+    "city": "Hiroshima",
+    "zip": "732-0057",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.70.0/23"
+    },
+    "id": "1.0.70.0/23",
+    "country": "JP",
+    "state": "Hiroshima",
+    "city": "Hiroshima",
+    "zip": "732-0057",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.72.0/21"
+    },
+    "id": "1.0.72.0/21",
+    "country": "JP",
+    "state": "Hiroshima",
+    "city": "Hiroshima",
+    "zip": "732-0057",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.80.0/24"
+    },
+    "id": "1.0.80.0/24",
+    "country": "JP",
+    "state": "Shimane",
+    "city": "Matsue",
+    "zip": "690-0015",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.81.0/24"
+    },
+    "id": "1.0.81.0/24",
+    "country": "JP",
+    "state": "Yamaguchi",
+    "city": "Hikari",
+    "zip": "743-0021",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.82.0/24"
+    },
+    "id": "1.0.82.0/24",
+    "country": "JP",
+    "state": "Tottori",
+    "city": "Yonago",
+    "zip": "683-0846",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.83.0/24"
+    },
+    "id": "1.0.83.0/24",
+    "country": "JP",
+    "state": "Tottori",
+    "city": "Kurayoshi",
+    "zip": "682-0021",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.84.0/24"
+    },
+    "id": "1.0.84.0/24",
+    "country": "JP",
+    "state": "Tottori",
+    "city": "Tottori",
+    "zip": "680-0805",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.85.0/24"
+    },
+    "id": "1.0.85.0/24",
+    "country": "JP",
+    "state": "Shimane",
+    "city": "Matsue",
+    "zip": "690-0015",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.86.0/24"
+    },
+    "id": "1.0.86.0/24",
+    "country": "JP",
+    "state": "Okayama",
+    "city": "Okayama",
+    "zip": "700-0824",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.87.0/24"
+    },
+    "id": "1.0.87.0/24",
+    "country": "JP",
+    "state": "Yamaguchi",
+    "city": "Yamaguchi",
+    "zip": "754-0893",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.88.0/24"
+    },
+    "id": "1.0.88.0/24",
+    "country": "JP",
+    "state": "Shimane",
+    "city": "Izumo",
+    "zip": "693-0044",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.89.0/24"
+    },
+    "id": "1.0.89.0/24",
+    "country": "JP",
+    "state": "Tottori",
+    "city": "Kurayoshi",
+    "zip": "682-0021",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.90.0/24"
+    },
+    "id": "1.0.90.0/24",
+    "country": "JP",
+    "state": "Tottori",
+    "city": "Tottori",
+    "zip": "680-0805",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.91.0/24"
+    },
+    "id": "1.0.91.0/24",
+    "country": "JP",
+    "state": "Shimane",
+    "city": "Izumo",
+    "zip": "693-0044",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.92.0/24"
+    },
+    "id": "1.0.92.0/24",
+    "country": "JP",
+    "state": "Yamaguchi",
+    "city": "Hikari",
+    "zip": "743-0021",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.93.0/24"
+    },
+    "id": "1.0.93.0/24",
+    "country": "JP",
+    "state": "Hiroshima",
+    "city": "Hiroshima",
+    "zip": "732-0057",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.94.0/24"
+    },
+    "id": "1.0.94.0/24",
+    "country": "JP",
+    "state": "Tottori",
+    "city": "Yonago",
+    "zip": "683-0846",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.95.0/24"
+    },
+    "id": "1.0.95.0/24",
+    "country": "JP",
+    "state": "Tottori",
+    "city": "Kurayoshi",
+    "zip": "682-0021",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.96.0/24"
+    },
+    "id": "1.0.96.0/24",
+    "country": "JP",
+    "state": "Yamaguchi",
+    "city": "Hikari",
+    "zip": "743-0021",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.97.0/24"
+    },
+    "id": "1.0.97.0/24",
+    "country": "JP",
+    "state": "Shimane",
+    "city": "Izumo",
+    "zip": "693-0044",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.98.0/23"
+    },
+    "id": "1.0.98.0/23",
+    "country": "JP",
+    "state": "Yamaguchi",
+    "city": "Yamaguchi",
+    "zip": "754-0893",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.100.0/24"
+    },
+    "id": "1.0.100.0/24",
+    "country": "JP",
+    "state": "Shimane",
+    "city": "Izumo",
+    "zip": "693-0044",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.101.0/24"
+    },
+    "id": "1.0.101.0/24",
+    "country": "JP",
+    "state": "Shimane",
+    "city": "Matsue",
+    "zip": "690-0015",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.102.0/23"
+    },
+    "id": "1.0.102.0/23",
+    "country": "JP",
+    "state": "Yamaguchi",
+    "city": "Yamaguchi",
+    "zip": "754-0893",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.104.0/24"
+    },
+    "id": "1.0.104.0/24",
+    "country": "JP",
+    "state": "Yamaguchi",
+    "city": "Hikari",
+    "zip": "743-0021",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.105.0/24"
+    },
+    "id": "1.0.105.0/24",
+    "country": "JP",
+    "state": "Shimane",
+    "city": "Matsue",
+    "zip": "690-0015",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.106.0/24"
+    },
+    "id": "1.0.106.0/24",
+    "country": "JP",
+    "state": "Tottori",
+    "city": "Tottori",
+    "zip": "680-0805",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.107.0/24"
+    },
+    "id": "1.0.107.0/24",
+    "country": "JP",
+    "state": "Yamaguchi",
+    "city": "Yamaguchi",
+    "zip": "754-0893",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.108.0/24"
+    },
+    "id": "1.0.108.0/24",
+    "country": "JP",
+    "state": "Okayama",
+    "city": "Okayama",
+    "zip": "700-0824",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.109.0/24"
+    },
+    "id": "1.0.109.0/24",
+    "country": "JP",
+    "state": "Hiroshima",
+    "city": "Hiroshima",
+    "zip": "732-0057",
+    "timezone": "+09:00"
+  },
+  {
+    "$index": {
+      "cidr": "1.0.110.0/24"
+    },
+    "id": "1.0.110.0/24",
+    "country": "JP",
+    "state": "Shimane",
+    "city": "Izumo",
+    "zip": "693-0044",
+    "timezone": "+09:00"
+  }
+]`, buf.String())
+}

--- a/internal/ip2location/record.go
+++ b/internal/ip2location/record.go
@@ -1,0 +1,18 @@
+package ip2location
+
+type (
+	// A Record is a ip2location record.
+	Record struct {
+		Index    RecordIndex `json:"$index"`
+		ID       string      `json:"id"`
+		Country  string      `json:"country"`
+		State    string      `json:"state"`
+		City     string      `json:"city"`
+		Zip      string      `json:"zip"`
+		Timezone string      `json:"timezone"`
+	}
+	// A RecordIndex is how the record is indexed.
+	RecordIndex struct {
+		CIDR string `json:"cidr"`
+	}
+)

--- a/internal/ip2location/server.go
+++ b/internal/ip2location/server.go
@@ -1,0 +1,59 @@
+package ip2location
+
+import (
+	"net/http"
+
+	"github.com/pomerium/datasource/internal/jsonutil"
+)
+
+type serverConfig struct {
+	file string
+}
+
+// A ServerOption customizes the server config.
+type ServerOption func(*serverConfig)
+
+// WithFile sets the file for the config.
+func WithFile(file string) ServerOption {
+	return func(cfg *serverConfig) {
+		cfg.file = file
+	}
+}
+
+func getServerConfig(options ...ServerOption) *serverConfig {
+	cfg := new(serverConfig)
+	for _, option := range options {
+		option(cfg)
+	}
+	return cfg
+}
+
+// Server serves ip2location records
+type Server struct {
+	cfg *serverConfig
+}
+
+// NewServer creates a new Server.
+func NewServer(options ...ServerOption) *Server {
+	cfg := getServerConfig(options...)
+	return &Server{
+		cfg: cfg,
+	}
+}
+
+// ServeHTTP implements the http.Handler interface.
+func (srv *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	err := srv.serveHTTP(w, r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (srv *Server) serveHTTP(w http.ResponseWriter, r *http.Request) error {
+	dst := jsonutil.NewJSONArrayStream(w)
+	err := fileToJSON(dst, srv.cfg.file)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/jsonutil/jsonutil.go
+++ b/internal/jsonutil/jsonutil.go
@@ -1,0 +1,60 @@
+package jsonutil
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+)
+
+// A JSONArrayStream represents a streaming array of JSON objects.
+type JSONArrayStream struct {
+	buf               *bufio.Writer
+	closed, wroteOnce bool
+}
+
+// NewJSONArrayStream creates a new JSONArrayStream.
+func NewJSONArrayStream(dst io.Writer) *JSONArrayStream {
+	return &JSONArrayStream{
+		buf: bufio.NewWriter(dst),
+	}
+}
+
+// Close writes the ']' and flushes the stream.
+func (stream *JSONArrayStream) Close() error {
+	if stream.closed {
+		return nil
+	}
+	stream.closed = true
+
+	if stream.wroteOnce {
+		_, err := stream.buf.Write([]byte{'\n', ']'})
+		if err != nil {
+			return err
+		}
+	}
+	return stream.buf.Flush()
+}
+
+// Encode adds an object to the stream.
+func (stream *JSONArrayStream) Encode(obj any) error {
+	bs, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+
+	if !stream.wroteOnce {
+		stream.wroteOnce = true
+		_, err := stream.buf.Write([]byte{'[', '\n'})
+		if err != nil {
+			return err
+		}
+	} else {
+		_, err := stream.buf.Write([]byte{',', '\n'})
+		if err != nil {
+			return err
+		}
+	}
+
+	_, err = stream.buf.Write(bs)
+	return err
+}

--- a/internal/netutil/netutil.go
+++ b/internal/netutil/netutil.go
@@ -1,0 +1,125 @@
+package netutil
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+	"math/big"
+	"net/netip"
+)
+
+// ParseIPNumber converts a raw base-10 IP number into an IP address. For example:
+//
+//     42540986356047386130018232263459733504 == 2001:1890:17dd:4500::
+//
+// For numbers less than the max uint32 an IPv4 address is returned, else an IPv6 address is returned.
+func ParseIPNumber(rawIPNumber string) (addr netip.Addr, err error) {
+	n, ok := big.NewInt(0).SetString(rawIPNumber, 10)
+	if !ok {
+		return addr, fmt.Errorf("invalid ip number")
+	}
+
+	if n.BitLen() <= 32 {
+		var bs [4]byte
+		n.FillBytes(bs[:])
+		addr = netip.AddrFrom4(bs)
+		return addr, nil
+	}
+
+	var bs [16]byte
+	n.FillBytes(bs[:])
+	addr = netip.AddrFrom16(bs)
+
+	if addr.Is4In6() {
+		return netip.AddrFrom4(addr.As4()), nil
+	}
+
+	return addr, nil
+}
+
+// AddrRangeToPrefixes converts an ip address range into a list of CIDR prefixes.
+func AddrRangeToPrefixes(start, end netip.Addr) []netip.Prefix {
+	// IPV4 -> IPV6 range is not supported
+	if start.BitLen() != end.BitLen() {
+		return nil
+	}
+
+	switch start.Compare(end) {
+	case 0:
+		// addresses are equal, so return a /32 (or /128) cidr
+		prefix, _ := start.Prefix(start.BitLen())
+		return []netip.Prefix{prefix}
+	case 1:
+		// end is before start, so no cidrs
+		return nil
+	}
+
+	var prefixes []netip.Prefix
+	for start.Compare(end) <= 0 {
+		prefix, _ := start.Prefix(start.BitLen())
+	loop:
+		for i := start.BitLen() - 1; i >= 0; i-- {
+			p, _ := start.Prefix(i)
+			a1, a2 := PrefixToAddrRange(p)
+			if a1 != start {
+				break
+			}
+			switch a2.Compare(end) {
+			case -1:
+				prefix = p
+			case 0:
+				prefix = p
+				break loop
+			case 1:
+				break loop
+			}
+		}
+		prefixes = append(prefixes, prefix)
+		_, start = PrefixToAddrRange(prefix)
+		if start == end {
+			break
+		}
+		start = start.Next()
+	}
+	return prefixes
+}
+
+// PrefixToAddrRange returns a CIDR prefix's inclusive ip address range
+func PrefixToAddrRange(prefix netip.Prefix) (start, end netip.Addr) {
+	start = prefix.Masked().Addr()
+	end = transformAddr(start,
+		func(ip *uint32) {
+			shift := 32 - prefix.Bits()
+			*ip |= (1 << shift) - 1
+		},
+		func(hi, lo *uint64) {
+			shift := 128 - prefix.Bits()
+			if shift >= 64 {
+				shift -= 64
+				*hi |= (1 << shift) - 1
+				*lo = math.MaxUint64
+			} else {
+				*lo |= (1 << shift) - 1
+			}
+		},
+	)
+	return start, end
+}
+
+func transformAddr(addr netip.Addr, ipv4callback func(ip *uint32), ipv6callback func(hi, lo *uint64)) netip.Addr {
+	if addr.Is4() {
+		bs := addr.As4()
+		ip := binary.BigEndian.Uint32(bs[:])
+		ipv4callback(&ip)
+		binary.BigEndian.PutUint32(bs[:], ip)
+		return netip.AddrFrom4(bs)
+	}
+
+	bs := addr.As16()
+	hi := binary.BigEndian.Uint64(bs[0:8])
+	lo := binary.BigEndian.Uint64(bs[8:16])
+	ipv6callback(&hi, &lo)
+	binary.BigEndian.PutUint64(bs[0:8], hi)
+	binary.BigEndian.PutUint64(bs[8:16], lo)
+	return netip.AddrFrom16(bs)
+}

--- a/internal/netutil/netutil_test.go
+++ b/internal/netutil/netutil_test.go
@@ -1,0 +1,66 @@
+package netutil
+
+import (
+	"errors"
+	"net/netip"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseIPNumber(t *testing.T) {
+	for _, testCase := range []struct {
+		raw    string
+		expect netip.Addr
+		err    error
+	}{
+		{"0", netip.MustParseAddr("0.0.0.0"), nil},
+		{"4294967295", netip.MustParseAddr("255.255.255.255"), nil},
+		{"4294967296", netip.MustParseAddr("::1:0:0"), nil},
+		{"42540986356047386130018232263459733504", netip.MustParseAddr("2001:1890:17dd:4500::"), nil},
+		{"340282366920938463463374607431768211455", netip.MustParseAddr("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"), nil},
+		{"2001:1890:17dd:4500::", netip.Addr{}, errors.New("invalid ip number")},
+	} {
+		actual, err := ParseIPNumber(testCase.raw)
+		assert.Equal(t, testCase.err, err)
+		assert.Equal(t, testCase.expect.String(), actual.String())
+	}
+}
+
+func TestAddrRangeToPrefixes(t *testing.T) {
+	for _, testCase := range []struct {
+		start, end, expect string
+	}{
+		{"192.168.0.1", "192.168.0.1", "192.168.0.1/32"},
+		{"192.168.0.0", "192.168.0.255", "192.168.0.0/24"},
+		{"192.168.0.96", "192.168.0.255", "192.168.0.96/27,192.168.0.128/25"},
+	} {
+		start := netip.MustParseAddr(testCase.start)
+		end := netip.MustParseAddr(testCase.end)
+		actual := AddrRangeToPrefixes(start, end)
+		var actualStrs []string
+		for _, p := range actual {
+			actualStrs = append(actualStrs, p.String())
+		}
+		assert.Equal(t, testCase.expect, strings.Join(actualStrs, ","),
+			"start=%s end=%s", start, end)
+	}
+}
+
+func TestPrefixToAddrRange(t *testing.T) {
+	for _, testCase := range []struct {
+		prefix, expectedStart, expectedEnd string
+	}{
+		{"10.0.0.0/8", "10.0.0.0", "10.255.255.255"},
+		{"fc00::/7", "fc00::", "fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"},
+		{"::ffff:0:0/96", "::ffff:0.0.0.0", "::ffff:255.255.255.255"},
+	} {
+		prefix := netip.MustParsePrefix(testCase.prefix)
+		start, end := PrefixToAddrRange(prefix)
+		assert.Equal(t, testCase.expectedStart, start.String(),
+			"prefix=%s", prefix)
+		assert.Equal(t, testCase.expectedEnd, end.String(),
+			"prefix=%s", prefix)
+	}
+}


### PR DESCRIPTION
## Summary
Add a datasource for the ip2location geoip database. These records can be used with `request.ip` lookups.

## Related issues
Fixes #2522

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
