### PR TITLE
zenefits: filter out people on vacation

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -198,8 +198,6 @@ github.com/go-playground/locales v0.14.0 h1:u50s323jtVGugKlcYeyzC0etD1HifMjqmJqb
 github.com/go-playground/locales v0.14.0/go.mod h1:sawfccIbzZTqEDETgFXqTho0QybSa7l++s0DH+LDiLs=
 github.com/go-playground/universal-translator v0.18.0 h1:82dyy6p4OuJq4/CByFNOn/jYrnRPArHwAcmLoJZxyho=
 github.com/go-playground/universal-translator v0.18.0/go.mod h1:UvRDBj+xPUEGrFYl+lu/H90nyDXpg0fqeB/AQUGNTVA=
-github.com/go-playground/validator/v10 v10.10.1 h1:uA0+amWMiglNZKZ9FJRKUAe9U3RX91eVn1JYXMWt7ig=
-github.com/go-playground/validator/v10 v10.10.1/go.mod h1:i+3WkQ1FvaUjjxh1kSvIA4dMGDBiPU55YFDl0WbKdWU=
 github.com/go-playground/validator/v10 v10.11.0 h1:0W+xRM511GY47Yy3bZUbJVitCNg2BOGlCyvTqsp/xIw=
 github.com/go-playground/validator/v10 v10.11.0/go.mod h1:i+3WkQ1FvaUjjxh1kSvIA4dMGDBiPU55YFDl0WbKdWU=
 github.com/go-redis/redis v6.15.8+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=

--- a/internal/util/mapstructure.go
+++ b/internal/util/mapstructure.go
@@ -36,6 +36,20 @@ func (d DateTime) MarshalJSON() ([]byte, error) {
 	return json.Marshal(d.tm.Format(d.layout))
 }
 
+// String returns string representation in the target layout
+func (d DateTime) String() string {
+	if d.tm.IsZero() {
+		return ""
+	}
+
+	return d.tm.Format(d.layout)
+}
+
+// NewDateTime creates new date time object
+func NewDateTime(tm time.Time, layout string) DateTime {
+	return DateTime{tm, layout}
+}
+
 // DateTimeDecodeHook parses date time that's supplied in a non-standard layout
 // if layout does not contain a time zone, a location need be provided
 func DateTimeDecodeHook(layout string, location *time.Location) mapstructure.DecodeHookFuncType {

--- a/internal/zenefits/objects.go
+++ b/internal/zenefits/objects.go
@@ -19,7 +19,7 @@ type List[T Kind] struct {
 
 // Kind represents an object kind
 type Kind interface {
-	Person | Department | Location
+	Person | Department | Location | Vacation
 }
 
 // Person see https://developers.zenefits.com/docs/people
@@ -48,6 +48,11 @@ type Person struct {
 	City    string `json:"city" mapstructure:"home_city,omitempty"`
 	Street1 string `json:"street1" mapstructure:"home_street1,omitempty"`
 	Street2 string `json:"street2" mapstructure:"home_street2,omitempty"`
+}
+
+// Vacation see https://developers.zenefits.com/docs/vacation-requests
+type Vacation struct {
+	Person Person `json:"person"`
 }
 
 // Department see https://developers.zenefits.com/docs/department

--- a/internal/zenefits/testdata/vacations.json
+++ b/internal/zenefits/testdata/vacations.json
@@ -1,0 +1,21 @@
+{
+  "status": 200,
+  "object": "/meta/response",
+  "data": {
+    "url": "https://api.zenefits.com/time_off/vacation_requests",
+    "next_url": null,
+    "object": "/meta/list",
+    "data": [
+      {
+        "end_date": "2022-05-06",
+        "object": "/time_off/vacation_requests",
+        "start_date": "2022-05-03",
+        "person": {
+          "id": "26455996"
+        },
+        "id": "21135013"
+      }
+    ]
+  },
+  "error": null
+}


### PR DESCRIPTION
## Summary

Adds support to filter out people marked with approved vacation in Zenefits. 
Requires time zone as api uses dates and not datetime. 

## Related issues

https://github.com/pomerium/pomerium-console/issues/2524

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
