### PR TITLE
disable renovate dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,3 @@
 {
-  "extends": [
-    "config:base"
-  ]
+  "extends": ["config:base", ":disableDependencyDashboard"]
 }


### PR DESCRIPTION
## Summary

Disables Renovate bot dashboard. 

## Related issues

https://github.com/pomerium/datasource/issues/3

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
