### PR TITLE
dependabot: add docker support

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,3 +10,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/static:latest-${TARGETARCH:-amd64}
+FROM gcr.io/distroless/static:latest@sha256:21d3f84a4f37c36199fd07ad5544dcafecc17776e3f3628baf9a57c8c0181b3f
 WORKDIR /pomerium
 COPY pomerium* /bin/
 ENTRYPOINT [ "/bin/pomerium-datasource" ]

--- a/pomerium-datasource-ip2location.dockerfile
+++ b/pomerium-datasource-ip2location.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest as curl
+FROM ubuntu:latest@sha256:b6b83d3c331794420340093eb706a6f152d9c1fa51b262d9bf34594887c2c7ac as curl
 
 RUN apt-get update && apt-get install -y curl
 
@@ -9,7 +9,7 @@ RUN --mount=type=secret,id=download_token \
     -o /download/IP2LOCATION-LITE-DB1.CSV.ZIP \
     "https://www.ip2location.com/download/?token=${DOWNLOAD_TOKEN}&file=DB1LITECSV"
 
-FROM golang:1.18-buster as build
+FROM golang:1.18-buster@sha256:6960d62610b18b7224d2c5572b4bb177890b9ab7bf70ebaf34e2e9ca662a46e9 as build
 
 WORKDIR /build
 
@@ -22,7 +22,7 @@ COPY ./cmd/ ./cmd/
 COPY ./internal/ ./internal/
 RUN make build
 
-FROM gcr.io/distroless/base-debian11
+FROM gcr.io/distroless/base-debian11@sha256:a08c76433d484340bd97013b5d868edfba797fbf83dc82174ebd0768d12f491d
 
 COPY --from=build /build/bin/* /bin/
 COPY --from=curl /download/IP2LOCATION-LITE-DB1.CSV.ZIP /usr/share/IP2LOCATION-LITE-DB1.CSV.ZIP

--- a/pomerium-datasource.dockerfile
+++ b/pomerium-datasource.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-buster as build
+FROM golang:1.18-buster@sha256:6960d62610b18b7224d2c5572b4bb177890b9ab7bf70ebaf34e2e9ca662a46e9  as build
 
 WORKDIR /build
 
@@ -11,7 +11,7 @@ COPY ./cmd/ ./cmd/
 COPY ./internal/ ./internal/
 RUN make build
 
-FROM gcr.io/distroless/base-debian11
+FROM gcr.io/distroless/base-debian11@sha256:a08c76433d484340bd97013b5d868edfba797fbf83dc82174ebd0768d12f491d
 
 COPY --from=build /build/bin/* /bin/
 


### PR DESCRIPTION
## Summary
Add docker support for dependabot. Also pin the docker dependencies.