### PR TITLE
okta: rename ProviderURL to URL

### DIFF
--- a/pkg/directory/okta/config.go
+++ b/pkg/directory/okta/config.go
@@ -2,7 +2,6 @@ package okta
 
 import (
 	"net/http"
-	"net/url"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -20,11 +19,11 @@ const (
 )
 
 type config struct {
-	apiKey      string
-	batchSize   int
-	httpClient  *http.Client
-	logger      zerolog.Logger
-	providerURL *url.URL
+	apiKey     string
+	batchSize  int
+	httpClient *http.Client
+	logger     zerolog.Logger
+	url        string
 }
 
 // An Option configures the Okta Provider.
@@ -58,10 +57,10 @@ func WithLogger(logger zerolog.Logger) Option {
 	}
 }
 
-// WithProviderURL sets the provider URL option.
-func WithProviderURL(uri *url.URL) Option {
+// WithURL sets the URL option.
+func WithURL(url string) Option {
 	return func(cfg *config) {
-		cfg.providerURL = uri
+		cfg.url = url
 	}
 }
 

--- a/pkg/directory/okta/okta.go
+++ b/pkg/directory/okta/okta.go
@@ -5,4 +5,7 @@ import (
 	"errors"
 )
 
-var ErrProviderURLNotDefined = errors.New("okta: provider url not defined")
+// errors
+var (
+	ErrInvalidURL = errors.New("okta: invalid URL")
+)

--- a/pkg/directory/okta/okta_test.go
+++ b/pkg/directory/okta/okta_test.go
@@ -166,7 +166,7 @@ func TestProvider_GetDirectory(t *testing.T) {
 
 	p := New(
 		WithAPIKey("APITOKEN"),
-		WithProviderURL(mustParseURL(srv.URL)),
+		WithURL(srv.URL),
 	)
 	groups, users, err := p.GetDirectory(context.Background())
 	assert.NoError(t, err)
@@ -211,7 +211,7 @@ func TestProvider_UserGroupsQueryUpdated(t *testing.T) {
 
 	p := New(
 		WithAPIKey("APITOKEN"),
-		WithProviderURL(mustParseURL(srv.URL)),
+		WithURL(srv.URL),
 	)
 	groups, users, err := p.GetDirectory(context.Background())
 	assert.NoError(t, err)


### PR DESCRIPTION
## Summary
To be more consistent with other providers, use `URL` instead of `ProviderURL` as an option to Okta.

## Related issues
- https://github.com/pomerium/pomerium-console/issues/2820


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
