### PR TITLE
google: remove http client option

### DIFF
--- a/pkg/directory/google/config.go
+++ b/pkg/directory/google/config.go
@@ -1,13 +1,10 @@
 package google
 
 import (
-	"net/http"
 	"os"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
-
-	"github.com/pomerium/datasource/internal/httputil"
 )
 
 const (
@@ -15,7 +12,6 @@ const (
 )
 
 type config struct {
-	httpClient      *http.Client
 	logger          zerolog.Logger
 	impersonateUser string
 	jsonKey         []byte
@@ -25,13 +21,6 @@ type config struct {
 
 // An Option changes the configuration for the Google directory provider.
 type Option func(cfg *config)
-
-// WithHTTPClient sets the http client option.
-func WithHTTPClient(httpClient *http.Client) Option {
-	return func(cfg *config) {
-		cfg.httpClient = httpClient
-	}
-}
 
 // WithImpersonateUser sets the impersonate user in the config.
 func WithImpersonateUser(impersonateUser string) Option {
@@ -70,19 +59,12 @@ func WithURL(url string) Option {
 
 func getConfig(opts ...Option) *config {
 	cfg := new(config)
-	WithHTTPClient(http.DefaultClient)(cfg)
 	WithLogger(log.Logger)(cfg)
 	WithURL(defaultProviderURL)(cfg)
 	for _, opt := range opts {
 		opt(cfg)
 	}
 	return cfg
-}
-
-func (cfg *config) getHTTPClient() *http.Client {
-	return httputil.NewLoggingClient(cfg.logger, cfg.httpClient, func(event *zerolog.Event) *zerolog.Event {
-		return event.Str("idp", "google")
-	})
 }
 
 func (cfg *config) getJSONKey() ([]byte, error) {

--- a/pkg/directory/google/provider.go
+++ b/pkg/directory/google/provider.go
@@ -170,7 +170,6 @@ func (p *Provider) getAPIClient(ctx context.Context) (*admin.Service, error) {
 	ts := config.TokenSource(ctx)
 
 	p.apiClient, err = admin.NewService(ctx,
-		option.WithHTTPClient(p.cfg.getHTTPClient()),
 		option.WithTokenSource(ts),
 		option.WithEndpoint(p.cfg.url))
 	if err != nil {


### PR DESCRIPTION
## Summary
I made this exact same mistake in Core. The `HTTPClient` option for the Google Admin SDK overrides the `TokenSource` causing credentials to fail.

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
