### PR TITLE
httputil: add serve methods for caching

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80
 	github.com/vektah/gqlparser v1.3.1
+	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
 	golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783
 	golang.org/x/sync v0.0.0-20220929204114-8fcdb60fdcc0
 	google.golang.org/api v0.100.0
@@ -187,7 +188,6 @@ require (
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.23.0 // indirect
 	golang.org/x/crypto v0.1.0 // indirect
-	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
 	golang.org/x/exp/typeparams v0.0.0-20220827204233-334a2380cb91 // indirect
 	golang.org/x/mod v0.6.0 // indirect
 	golang.org/x/net v0.1.0 // indirect

--- a/internal/httputil/serve.go
+++ b/internal/httputil/serve.go
@@ -1,0 +1,80 @@
+package httputil
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+	"io"
+	"net/http"
+	"sort"
+	"time"
+
+	"golang.org/x/exp/maps"
+)
+
+// EncodeBundle encodes a bundle to a writer.
+func EncodeBundle(w io.Writer, bundle map[string]any) error {
+	zw := zip.NewWriter(w)
+	defer zw.Close()
+
+	recordTypes := maps.Keys(bundle)
+	sort.Strings(recordTypes)
+
+	for _, recordType := range recordTypes {
+		fw, err := zw.Create(recordType + ".json")
+		if err != nil {
+			return fmt.Errorf("failed to create %s file: %w", recordType, err)
+		}
+		err = json.NewEncoder(fw).Encode(bundle[recordType])
+		if err != nil {
+			return fmt.Errorf("failed to write %s data: %w", recordType, err)
+		}
+	}
+
+	err := zw.Close()
+	if err != nil {
+		return fmt.Errorf("failed to close zip file: %w", err)
+	}
+
+	return nil
+}
+
+// ServeBundle serves a bundle of data.
+func ServeBundle(w http.ResponseWriter, r *http.Request, bundle map[string]any) error {
+	var buf bytes.Buffer
+	err := EncodeBundle(&buf, bundle)
+	if err != nil {
+		return fmt.Errorf("failed to encode bundle: %w", err)
+	}
+
+	w.Header().Set("Content-Type", "application/zip")
+	return ServeData(w, r, "bundle.zip", buf.Bytes())
+}
+
+// ServeContent serves content over http.
+func ServeContent(
+	w http.ResponseWriter,
+	r *http.Request,
+	name string,
+	hash uint64,
+	content io.ReadSeeker,
+) error {
+	w.Header().Set("ETag", fmt.Sprintf(`"%x"`, hash))
+	http.ServeContent(w, r, name, time.Now(), content)
+	return nil
+}
+
+// ServeData serves data over http.
+func ServeData(
+	w http.ResponseWriter,
+	r *http.Request,
+	name string,
+	data []byte,
+) error {
+	hasher := fnv.New64()
+	_, _ = hasher.Write(data)
+	h := hasher.Sum64()
+	return ServeContent(w, r, name, h, bytes.NewReader(data))
+}

--- a/internal/ip2location/server.go
+++ b/internal/ip2location/server.go
@@ -1,8 +1,10 @@
 package ip2location
 
 import (
+	"bytes"
 	"net/http"
 
+	"github.com/pomerium/datasource/internal/httputil"
 	"github.com/pomerium/datasource/internal/jsonutil"
 )
 
@@ -50,10 +52,11 @@ func (srv *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (srv *Server) serveHTTP(w http.ResponseWriter, r *http.Request) error {
-	dst := jsonutil.NewJSONArrayStream(w)
+	var buf bytes.Buffer
+	dst := jsonutil.NewJSONArrayStream(&buf)
 	err := fileToJSON(dst, srv.cfg.file)
 	if err != nil {
 		return err
 	}
-	return nil
+	return httputil.ServeData(w, r, "ip2location.json", buf.Bytes())
 }

--- a/pkg/directory/http_test.go
+++ b/pkg/directory/http_test.go
@@ -57,10 +57,20 @@ func TestHandler(t *testing.T) {
 		defer res.Body.Close()
 
 		assert.Equal(t, 200, res.StatusCode)
+		assert.Equal(t, `"d3b7677a8420759f"`, res.Header.Get("ETag"))
 		groups, users, err := decodeBundle(res.Body)
 		assert.NoError(t, err)
 		assert.Equal(t, expect.groups, groups)
 		assert.Equal(t, expect.users, users)
+
+		req.Header.Set("If-None-Match", `"d3b7677a8420759f"`)
+		res, err = http.DefaultClient.Do(req)
+		if !assert.NoError(t, err) {
+			return
+		}
+		defer res.Body.Close()
+
+		assert.Equal(t, 304, res.StatusCode)
 	})
 	t.Run("error", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
## Summary
Add `ServeXXX` methods to `httputil` to implement caching via the `ServeContent` function in the `http` package. This supports ETags computed by taking the `fnv` hash of a slice of bytes.

This does mean we will buffer all results in memory, but it can save dumping the whole response by returning a 304 when nothing changes.

## Related issues
Fixes https://github.com/pomerium/datasource/issues/92

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
