### PR TITLE
datasource/cognito: add region

### DIFF
--- a/cmd/pomerium-datasource/directory.go
+++ b/cmd/pomerium-datasource/directory.go
@@ -55,13 +55,15 @@ func directoryCommand(logger zerolog.Logger) *cobra.Command {
 			}),
 		directorySubCommand(logger, "cognito",
 			func(flags *pflag.FlagSet) func() directory.Provider {
-				userPoolID := optionalStringFlag(flags, "user-pool-id", "user pool id")
 				accessKeyID := optionalStringFlag(flags, "access-key-id", "access key id")
+				region := optionalStringFlag(flags, "region", "aws region")
 				secretAccessKey := optionalStringFlag(flags, "secret-access-key", "secret access key")
 				sessionToken := optionalStringFlag(flags, "session-token", "session token")
+				userPoolID := optionalStringFlag(flags, "user-pool-id", "user pool id")
 				return func() directory.Provider {
 					return cognito.New(
 						cognito.WithAccessKeyID(*accessKeyID),
+						cognito.WithRegion(*region),
 						cognito.WithSecretAccessKey(*secretAccessKey),
 						cognito.WithSessionToken(*sessionToken),
 						cognito.WithUserPoolID(*userPoolID),

--- a/pkg/directory/cognito/config.go
+++ b/pkg/directory/cognito/config.go
@@ -13,6 +13,7 @@ type config struct {
 	accessKeyID     string
 	httpClient      *http.Client
 	logger          zerolog.Logger
+	region          string
 	secretAccessKey string
 	sessionToken    string
 	userPoolID      string
@@ -38,6 +39,13 @@ func WithHTTPClient(httpClient *http.Client) Option {
 func WithLogger(logger zerolog.Logger) Option {
 	return func(cfg *config) {
 		cfg.logger = logger
+	}
+}
+
+// WithRegion sets the region config option.
+func WithRegion(region string) Option {
+	return func(cfg *config) {
+		cfg.region = region
 	}
 }
 

--- a/pkg/directory/cognito/provider.go
+++ b/pkg/directory/cognito/provider.go
@@ -108,6 +108,10 @@ func (p *Provider) getClient(ctx context.Context) (*cognitoidentityprovider.Clie
 		return nil, err
 	}
 
+	if p.cfg.region != "" {
+		cfg.Region = p.cfg.region
+	}
+
 	p.client = cognitoidentityprovider.NewFromConfig(cfg)
 	return p.client, nil
 }


### PR DESCRIPTION
## Summary
For Cognito, the AWS region is required if there is no `~/.aws/config` with it set, so add it as an option.

## Related issues
- https://github.com/pomerium/internal/issues/1691


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
