### PR TITLE
datasource/okta: refactor okta provider

### DIFF
--- a/cmd/pomerium-datasource/directory.go
+++ b/cmd/pomerium-datasource/directory.go
@@ -109,10 +109,12 @@ func directoryCommand(logger zerolog.Logger) *cobra.Command {
 		directorySubCommand(logger, "okta",
 			func(flags *pflag.FlagSet) func() directory.Provider {
 				apiKey := requiredStringFlag(flags, "api-key", "api key")
+				url := requiredStringFlag(flags, "url", "url")
 				return func() directory.Provider {
 					return okta.New(
 						okta.WithAPIKey(*apiKey),
 						okta.WithLogger(logger),
+						okta.WithURL(*url),
 					)
 				}
 			}),

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/mitchellh/mapstructure v1.5.0
+	github.com/okta/okta-sdk-golang/v2 v2.20.0
 	github.com/rs/zerolog v1.33.0
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
@@ -75,6 +76,7 @@ require (
 	github.com/butuzov/mirror v1.2.0 // indirect
 	github.com/catenacyber/perfsprint v0.7.1 // indirect
 	github.com/ccojocar/zxcvbn-go v1.0.2 // indirect
+	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/charithe/durationcheck v0.0.10 // indirect
 	github.com/chavacava/garif v0.1.0 // indirect
@@ -92,6 +94,7 @@ require (
 	github.com/fzipp/gocyclo v0.6.0 // indirect
 	github.com/ghostiam/protogetter v0.3.6 // indirect
 	github.com/go-critic/go-critic v0.11.4 // indirect
+	github.com/go-jose/go-jose/v3 v3.0.0 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
@@ -137,6 +140,7 @@ require (
 	github.com/jjti/go-spancheck v0.6.1 // indirect
 	github.com/julz/importas v0.1.0 // indirect
 	github.com/karamaru-alpha/copyloopvar v1.1.0 // indirect
+	github.com/kelseyhightower/envconfig v1.4.0 // indirect
 	github.com/kisielk/errcheck v1.7.0 // indirect
 	github.com/kkHAIKE/contextcheck v1.1.5 // indirect
 	github.com/kulti/thelper v0.6.3 // indirect
@@ -166,6 +170,7 @@ require (
 	github.com/nishanths/predeclared v0.2.2 // indirect
 	github.com/nunnatsa/ginkgolinter v0.16.2 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
+	github.com/patrickmn/go-cache v0.0.0-20180815053127-5633e0862627 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,8 @@ github.com/catenacyber/perfsprint v0.7.1 h1:PGW5G/Kxn+YrN04cRAZKC+ZuvlVwolYMrIyy
 github.com/catenacyber/perfsprint v0.7.1/go.mod h1:/wclWYompEyjUD2FuIIDVKNkqz7IgBIWXIH3V0Zol50=
 github.com/ccojocar/zxcvbn-go v1.0.2 h1:na/czXU8RrhXO4EZme6eQJLR4PzcGsahsBOAwU6I3Vg=
 github.com/ccojocar/zxcvbn-go v1.0.2/go.mod h1:g1qkXtUSvHP8lhHp5GrSmTz6uWALGRMQdw6Qnz/hi60=
+github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=
+github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -206,6 +208,8 @@ github.com/go-critic/go-critic v0.11.4/go.mod h1:2QAdo4iuLik5S9YG0rT4wcZ8QxwHYkr
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-jose/go-jose/v3 v3.0.0 h1:s6rrhirfEP/CGIoc6p+PZAeogN2SxKav6Wp7+dyMWVo=
+github.com/go-jose/go-jose/v3 v3.0.0/go.mod h1:RNkWWRld676jZEYoV3+XK8L2ZnNSvIsxFMht0mSX+u8=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
@@ -407,6 +411,8 @@ github.com/julz/importas v0.1.0 h1:F78HnrsjY3cR7j0etXy5+TU1Zuy7Xt08X/1aJnH5xXY=
 github.com/julz/importas v0.1.0/go.mod h1:oSFU2R4XK/P7kNBrnL/FEQlDGN1/6WoxXEjSSXO0DV0=
 github.com/karamaru-alpha/copyloopvar v1.1.0 h1:x7gNyKcC2vRBO1H2Mks5u1VxQtYvFiym7fCjIP8RPos=
 github.com/karamaru-alpha/copyloopvar v1.1.0/go.mod h1:u7CIfztblY0jZLOQZgH3oYsJzpC2A7S6u/lfgSXHy0k=
+github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
+github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kisielk/errcheck v1.7.0 h1:+SbscKmWJ5mOK/bO1zS60F5I9WwZDWOfRsC4RwfwRV0=
 github.com/kisielk/errcheck v1.7.0/go.mod h1:1kLL+jV4e+CFfueBmI1dSK2ADDyQnlrnrY/FqKluHJQ=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -489,6 +495,8 @@ github.com/nishanths/predeclared v0.2.2 h1:V2EPdZPliZymNAn79T8RkNApBjMmVKh5XRpLm
 github.com/nishanths/predeclared v0.2.2/go.mod h1:RROzoN6TnGQupbC+lqggsOlcgysk3LMK/HI84Mp280c=
 github.com/nunnatsa/ginkgolinter v0.16.2 h1:8iLqHIZvN4fTLDC0Ke9tbSZVcyVHoBs0HIbnVSxfHJk=
 github.com/nunnatsa/ginkgolinter v0.16.2/go.mod h1:4tWRinDN1FeJgU+iJANW/kz7xKN5nYRAOfJDQUS9dOQ=
+github.com/okta/okta-sdk-golang/v2 v2.20.0 h1:EDKM+uOPfihOMNwgHMdno+NAsIfyXkVnoFAYVPay0YU=
+github.com/okta/okta-sdk-golang/v2 v2.20.0/go.mod h1:FMy5hN5G8Rd/VoS0XrfyPPhIfOVo78ZK7lvwiQRS2+U=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo/v2 v2.17.3 h1:oJcvKpIb7/8uLpDDtnQuf18xVnwKp8DTD7DQ6gTd/MU=
@@ -502,6 +510,8 @@ github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJ
 github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
 github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
+github.com/patrickmn/go-cache v0.0.0-20180815053127-5633e0862627 h1:pSCLCl6joCFRnjpeojzOpEYs4q7Vditq8fySFG5ap3Y=
+github.com/patrickmn/go-cache v0.0.0-20180815053127-5633e0862627/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=
@@ -621,6 +631,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -712,6 +723,7 @@ golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=

--- a/pkg/directory/okta/config.go
+++ b/pkg/directory/okta/config.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// Okta use ISO-8601, see https://developer.okta.com/docs/reference/api-overview/#media-types
-	filterDateFormat = "2006-01-02T15:04:05.999Z"
+	filterDateFormat = "2006-01-02T15:04:05.000Z"
 
 	batchSize        = 200
 	readLimit        = 100 * 1024

--- a/pkg/directory/okta/config.go
+++ b/pkg/directory/okta/config.go
@@ -3,6 +3,7 @@ package okta
 import (
 	"net/http"
 
+	"github.com/okta/okta-sdk-golang/v2/okta"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
@@ -19,11 +20,12 @@ const (
 )
 
 type config struct {
-	apiKey     string
-	batchSize  int
-	httpClient *http.Client
-	logger     zerolog.Logger
-	url        string
+	apiKey      string
+	batchSize   int
+	httpClient  *http.Client
+	logger      zerolog.Logger
+	oktaOptions []okta.ConfigSetter
+	url         string
 }
 
 // An Option configures the Okta Provider.
@@ -54,6 +56,13 @@ func WithHTTPClient(httpClient *http.Client) Option {
 func WithLogger(logger zerolog.Logger) Option {
 	return func(cfg *config) {
 		cfg.logger = logger
+	}
+}
+
+// WithOktaOptions sets the okta options in the config.
+func WithOktaOptions(oktaOptions ...okta.ConfigSetter) Option {
+	return func(cfg *config) {
+		cfg.oktaOptions = oktaOptions
 	}
 }
 

--- a/pkg/directory/okta/okta.go
+++ b/pkg/directory/okta/okta.go
@@ -2,10 +2,92 @@
 package okta
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"time"
+
+	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v2/okta/query"
 )
 
 // errors
 var (
 	ErrInvalidURL = errors.New("okta: invalid URL")
 )
+
+func listAllGroups(
+	ctx context.Context,
+	client *okta.Client,
+	batchSize int,
+) ([]*okta.Group, error) {
+	groups, err := listAll(ctx, func(ctx context.Context) ([]*okta.Group, *okta.Response, error) {
+		return client.Group.ListGroups(ctx, &query.Params{
+			Limit: int64(batchSize),
+		})
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error listing all groups: %w", err)
+	}
+
+	return groups, nil
+}
+
+func listChangedGroups(
+	ctx context.Context,
+	client *okta.Client,
+	lastUpdated, lastMembershipUpdated time.Time,
+	batchSize int,
+) ([]*okta.Group, error) {
+	groups, err := listAll(ctx, func(ctx context.Context) ([]*okta.Group, *okta.Response, error) {
+		filter := fmt.Sprintf(`lastUpdated gt "%s" or lastMembershipUpdated gt "%s"`,
+			lastUpdated.UTC().Format(filterDateFormat),
+			lastMembershipUpdated.UTC().Format(filterDateFormat))
+
+		return client.Group.ListGroups(ctx, &query.Params{
+			Limit:  int64(batchSize),
+			Filter: filter,
+		})
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error listing changed groups: %w", err)
+	}
+
+	return groups, nil
+}
+
+func listGroupUsers(
+	ctx context.Context,
+	client *okta.Client,
+	groupID string,
+	batchSize int,
+) ([]*okta.User, error) {
+	users, err := listAll(ctx, func(ctx context.Context) ([]*okta.User, *okta.Response, error) {
+		return client.Group.ListGroupUsers(ctx, groupID, &query.Params{
+			Limit: int64(batchSize),
+		})
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error listing group users: %w", err)
+	}
+
+	return users, nil
+}
+
+func listAll[T any](ctx context.Context, f func(ctx context.Context) ([]T, *okta.Response, error)) ([]T, error) {
+	els, res, err := f(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for res.HasNextPage() {
+		var next []T
+		res, err = res.Next(ctx, &next)
+		if err != nil {
+			return nil, err
+		}
+		els = append(els, next...)
+	}
+
+	return els, nil
+}

--- a/pkg/directory/okta/okta_test.go
+++ b/pkg/directory/okta/okta_test.go
@@ -5,22 +5,21 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/stretchr/testify/assert"
-	"github.com/tomnomnom/linkheader"
 
 	"github.com/pomerium/datasource/pkg/directory"
 )
 
 type M = map[string]interface{}
 
-func newMockOkta(srv *httptest.Server, userEmailToGroups map[string][]string) http.Handler {
+func newMockOkta(userEmailToGroups map[string][]string) http.Handler {
 	getAllGroups := func() map[string]struct{} {
 		allGroups := map[string]struct{}{}
 		for _, groups := range userEmailToGroups {
@@ -59,32 +58,18 @@ func newMockOkta(srv *httptest.Server, userEmailToGroups map[string][]string) ht
 				sort.Strings(groups)
 
 				var result []M
-
-				found := r.URL.Query().Get("after") == ""
 				for i := range groups {
-					if found {
-						result = append(result, M{
-							"id": groups[i],
-							"profile": M{
-								"name": groups[i] + "-name",
-							},
-						})
-						break
-					}
-					found = r.URL.Query().Get("after") == groups[i]
+					result = append(result, M{
+						"id": groups[i],
+						"profile": M{
+							"name": groups[i] + "-name",
+						},
+						"lastUpdated":           time.Now().UTC().Format(filterDateFormat),
+						"lastMembershipUpdated": time.Now().UTC().Format(filterDateFormat),
+					})
 				}
 
-				if len(result) > 0 {
-					nextURL := mustParseURL(srv.URL).ResolveReference(r.URL)
-					q := nextURL.Query()
-					q.Set("after", result[0]["id"].(string))
-					nextURL.RawQuery = q.Encode()
-					w.Header().Set("Link", linkheader.Link{
-						URL: nextURL.String(),
-						Rel: "next",
-					}.String())
-				}
-
+				w.Header().Set("Content-Type", "application/json")
 				_ = json.NewEncoder(w).Encode(result)
 			})
 			r.Get("/{group}/users", func(w http.ResponseWriter, r *http.Request) {
@@ -120,29 +105,35 @@ func newMockOkta(srv *httptest.Server, userEmailToGroups map[string][]string) ht
 				sort.Slice(result, func(i, j int) bool {
 					return result[i]["id"].(string) < result[j]["id"].(string)
 				})
-
+				w.Header().Set("Content-Type", "application/json")
 				_ = json.NewEncoder(w).Encode(result)
 			})
 		})
 		r.Route("/users", func(r chi.Router) {
 			r.Get("/{user_id}/groups", func(w http.ResponseWriter, r *http.Request) {
-				var groups []apiGroupObject
+				var groups []any
 				for _, nm := range userEmailToGroups[chi.URLParam(r, "user_id")] {
-					obj := apiGroupObject{
-						ID: nm,
+					obj := map[string]any{
+						"id": nm,
+						"profile": map[string]any{
+							"name": nm,
+						},
 					}
-					obj.Profile.Name = nm
 					groups = append(groups, obj)
 				}
+				w.Header().Set("Content-Type", "application/json")
 				_ = json.NewEncoder(w).Encode(groups)
 			})
 			r.Get("/{user_id}", func(w http.ResponseWriter, r *http.Request) {
-				user := apiUserObject{
-					ID: chi.URLParam(r, "user_id"),
+				user := map[string]any{
+					"id": chi.URLParam(r, "user_id"),
+					"profile": map[string]any{
+						"email":     chi.URLParam(r, "user_id"),
+						"firstName": "first",
+						"lastName":  "last",
+					},
 				}
-				user.Profile.Email = chi.URLParam(r, "user_id")
-				user.Profile.FirstName = "first"
-				user.Profile.LastName = "last"
+				w.Header().Set("Content-Type", "application/json")
 				_ = json.NewEncoder(w).Encode(user)
 			})
 		})
@@ -158,7 +149,7 @@ func TestProvider_GetDirectory(t *testing.T) {
 		mockOkta.ServeHTTP(w, r)
 	}))
 	defer srv.Close()
-	mockOkta = newMockOkta(srv, map[string][]string{
+	mockOkta = newMockOkta(map[string][]string{
 		"a@example.com": {"user", "admin"},
 		"b@example.com": {"user", "test"},
 		"c@example.com": {"user"},
@@ -207,7 +198,7 @@ func TestProvider_UserGroupsQueryUpdated(t *testing.T) {
 		"c@example.com":       {"user"},
 		"updated@example.com": {"user-updated"},
 	}
-	mockOkta = newMockOkta(srv, userEmailToGroups)
+	mockOkta = newMockOkta(userEmailToGroups)
 
 	p := New(
 		WithAPIKey("APITOKEN"),
@@ -266,44 +257,4 @@ func TestProvider_UserGroupsQueryUpdated(t *testing.T) {
 		},
 	}, users)
 	assert.Len(t, groups, 4)
-
-	userEmailToGroups["b@example.com"] = []string{"user"}
-
-	groups, users, err = p.GetDirectory(context.Background())
-	assert.NoError(t, err)
-	assert.Equal(t, []directory.User{
-		{
-			ID:          "a@example.com",
-			GroupIDs:    []string{"admin", "user"},
-			DisplayName: "first last",
-			Email:       "a@example.com",
-		},
-		{
-			ID:          "b@example.com",
-			GroupIDs:    []string{"user"},
-			DisplayName: "first last",
-			Email:       "b@example.com",
-		},
-		{
-			ID:          "c@example.com",
-			GroupIDs:    []string{"user"},
-			DisplayName: "first last",
-			Email:       "c@example.com",
-		},
-		{
-			ID:          "updated@example.com",
-			GroupIDs:    []string{"user-updated"},
-			DisplayName: "first last",
-			Email:       "updated@example.com",
-		},
-	}, users)
-	assert.Len(t, groups, 3)
-}
-
-func mustParseURL(rawurl string) *url.URL {
-	u, err := url.Parse(rawurl)
-	if err != nil {
-		panic(err)
-	}
-	return u
 }

--- a/pkg/directory/okta/okta_test.go
+++ b/pkg/directory/okta/okta_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+	"github.com/okta/okta-sdk-golang/v2/okta"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/pomerium/datasource/pkg/directory"
@@ -157,6 +158,7 @@ func TestProvider_GetDirectory(t *testing.T) {
 
 	p := New(
 		WithAPIKey("APITOKEN"),
+		WithOktaOptions(okta.WithTestingDisableHttpsCheck(true)),
 		WithURL(srv.URL),
 	)
 	groups, users, err := p.GetDirectory(context.Background())
@@ -202,6 +204,7 @@ func TestProvider_UserGroupsQueryUpdated(t *testing.T) {
 
 	p := New(
 		WithAPIKey("APITOKEN"),
+		WithOktaOptions(okta.WithTestingDisableHttpsCheck(true)),
 		WithURL(srv.URL),
 	)
 	groups, users, err := p.GetDirectory(context.Background())

--- a/pkg/directory/okta/provider.go
+++ b/pkg/directory/okta/provider.go
@@ -61,8 +61,8 @@ func (p *Provider) GetDirectory(ctx context.Context) ([]directory.Group, []direc
 		})
 		for _, u := range p.groupMembers[g.Id] {
 			du := userLookup[u.Id]
-			du.DisplayName = getUserDisplayName(&u)
-			du.Email = getUserEmail(&u)
+			du.DisplayName = getUserDisplayName(u)
+			du.Email = getUserEmail(u)
 			du.GroupIDs = append(du.GroupIDs, g.Id)
 			sort.Strings(du.GroupIDs)
 			du.ID = u.Id
@@ -149,8 +149,8 @@ func (p *Provider) syncGroups(ctx context.Context, client *okta.Client, groups [
 	return nil
 }
 
-func getUserDisplayName(user *okta.User) string {
-	if user == nil || user.Profile == nil {
+func getUserDisplayName(user okta.User) string {
+	if user.Profile == nil {
 		return ""
 	}
 
@@ -159,8 +159,8 @@ func getUserDisplayName(user *okta.User) string {
 	return firstName + " " + lastName
 }
 
-func getUserEmail(user *okta.User) string {
-	if user == nil || user.Profile == nil {
+func getUserEmail(user okta.User) string {
+	if user.Profile == nil {
 		return ""
 	}
 

--- a/pkg/directory/okta/provider.go
+++ b/pkg/directory/okta/provider.go
@@ -2,266 +2,172 @@ package okta
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
-	"net/http"
-	"net/url"
 	"sort"
-	"strconv"
+	"sync"
 	"time"
 
-	"github.com/tomnomnom/linkheader"
+	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v2/okta/query"
+	"golang.org/x/exp/maps"
 
 	"github.com/pomerium/datasource/pkg/directory"
 )
 
 // A Provider is an Okta user group directory provider.
 type Provider struct {
-	cfg         *config
-	lastUpdated *time.Time
-	groups      map[string]directory.Group
+	cfg *config
+
+	mu           sync.Mutex
+	groups       map[string]okta.Group
+	groupMembers map[string][]okta.User
 }
 
 // New creates a new Provider.
 func New(options ...Option) *Provider {
 	return &Provider{
-		cfg:    getConfig(options...),
-		groups: make(map[string]directory.Group),
+		cfg: getConfig(options...),
+
+		groups:       make(map[string]okta.Group),
+		groupMembers: make(map[string][]okta.User),
 	}
 }
 
-// GetDirectory fetches the groups of which the user is a member
-// https://developer.okta.com/docs/reference/api/users/#get-user-s-groups
+// GetDirectory get's the full directory information for Okta.
 func (p *Provider) GetDirectory(ctx context.Context) ([]directory.Group, []directory.User, error) {
-	groups, err := p.getGroups(ctx)
+	ctx, client, err := okta.NewClient(ctx,
+		okta.WithHttpClientPtr(p.cfg.getHTTPClient()),
+		okta.WithOrgUrl(p.cfg.url),
+		okta.WithTestingDisableHttpsCheck(true),
+		okta.WithToken(p.cfg.apiKey))
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating okta client: %w", err)
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	err = p.sync(ctx, client)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	userLookup := map[string]apiUserObject{}
-	userIDToGroups := map[string][]string{}
-	for i := 0; i < len(groups); i++ {
-		group := groups[i]
-		users, err := p.getGroupMembers(ctx, group.ID)
-
-		// if we get a 404 on the member query, it means the group doesn't exist, so we should remove it from
-		// the cached lookup and the local groups list
-		var apiErr *APIError
-		if errors.As(err, &apiErr) && apiErr.HTTPStatusCode == http.StatusNotFound {
-			delete(p.groups, group.ID)
-			groups = append(groups[:i], groups[i+1:]...)
-			i--
-			continue
-		}
-
-		if err != nil {
-			return nil, nil, err
-		}
-		for _, u := range users {
-			userIDToGroups[u.ID] = append(userIDToGroups[u.ID], group.ID)
-			userLookup[u.ID] = u
-		}
-	}
-
-	var users []directory.User
-	for _, u := range userLookup {
-		groups := userIDToGroups[u.ID]
-		sort.Strings(groups)
-		users = append(users, directory.User{
-			ID:          u.ID,
-			GroupIDs:    groups,
-			DisplayName: u.getDisplayName(),
-			Email:       u.Profile.Email,
+	var groups []directory.Group
+	userLookup := map[string]directory.User{}
+	for _, g := range p.groups {
+		groups = append(groups, directory.Group{
+			ID:   g.Id,
+			Name: g.Profile.Name,
 		})
+		for _, u := range p.groupMembers[g.Id] {
+			du := userLookup[u.Id]
+			du.DisplayName = getUserDisplayName(&u)
+			du.Email = getUserEmail(&u)
+			du.GroupIDs = append(du.GroupIDs, g.Id)
+			sort.Strings(du.GroupIDs)
+			du.ID = u.Id
+			userLookup[u.Id] = du
+		}
 	}
+
+	users := maps.Values(userLookup)
+
+	// sort groups and users
+	sort.Slice(groups, func(i, j int) bool {
+		return groups[i].ID < groups[j].ID
+	})
 	sort.Slice(users, func(i, j int) bool {
 		return users[i].ID < users[j].ID
 	})
 	return groups, users, nil
 }
 
-func (p *Provider) getGroups(ctx context.Context) ([]directory.Group, error) {
-	groupURL, err := p.getURL("/api/v1/groups", func(q url.Values) {
-		q.Set("limit", strconv.Itoa(p.cfg.batchSize))
-		if p.lastUpdated != nil {
-			q.Set("filter", fmt.Sprintf(`lastUpdated gt "%[1]s" or lastMembershipUpdated gt "%[1]s"`, p.lastUpdated.UTC().Format(filterDateFormat)))
-		} else {
-			now := time.Now()
-			p.lastUpdated = &now
+func (p *Provider) sync(ctx context.Context, client *okta.Client) error {
+	var lastMembershipUpdated, lastUpdated time.Time
+	for _, g := range p.groups {
+		if g.LastMembershipUpdated != nil && g.LastMembershipUpdated.After(lastMembershipUpdated) {
+			lastMembershipUpdated = *g.LastMembershipUpdated
 		}
-	})
-	if err != nil {
-		return nil, err
+		if g.LastUpdated != nil && g.LastUpdated.After(lastUpdated) {
+			lastUpdated = *g.LastUpdated
+		}
 	}
 
-	for groupURL != "" {
-		var out []apiGroupObject
-		hdrs, err := p.apiGet(ctx, groupURL, &out)
+	var changedGroups []*okta.Group
+	if lastMembershipUpdated.IsZero() || lastUpdated.IsZero() {
+		// full sync
+		p.groups = make(map[string]okta.Group)
+		p.groupMembers = make(map[string][]okta.User)
+
+		var err error
+		changedGroups, _, err = client.Group.ListGroups(ctx, &query.Params{
+			Limit: int64(p.cfg.batchSize),
+		})
 		if err != nil {
-			return nil, fmt.Errorf("okta: error querying for groups: %w", err)
+			return fmt.Errorf("error querying all groups: %w", err)
 		}
-
-		for _, el := range out {
-			lu, _ := time.Parse(el.LastUpdated, filterDateFormat)
-			lmu, _ := time.Parse(el.LastMembershipUpdated, filterDateFormat)
-			if lu.After(*p.lastUpdated) {
-				p.lastUpdated = &lu
-			}
-			if lmu.After(*p.lastUpdated) {
-				p.lastUpdated = &lmu
-			}
-			p.groups[el.ID] = directory.Group{
-				ID:   el.ID,
-				Name: el.Profile.Name,
-			}
-		}
-		groupURL = getNextLink(hdrs)
-	}
-
-	groups := make([]directory.Group, 0, len(p.groups))
-	for _, dg := range p.groups {
-		groups = append(groups, dg)
-	}
-	return groups, nil
-}
-
-func (p *Provider) getGroupMembers(ctx context.Context, groupID string) (users []apiUserObject, err error) {
-	usersURL, err := p.getURL(fmt.Sprintf("/api/v1/groups/%s/users", groupID), func(qs url.Values) {
-		qs.Set("limit", fmt.Sprint(p.cfg.batchSize))
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	for usersURL != "" {
-		var out []apiUserObject
-		hdrs, err := p.apiGet(ctx, usersURL, &out)
+	} else {
+		// sync changes
+		var err error
+		filter := fmt.Sprintf(`lastUpdated gt "%s" or lastMembershipUpdated gt "%s"`,
+			lastUpdated.UTC().Format(filterDateFormat),
+			lastMembershipUpdated.UTC().Format(filterDateFormat))
+		changedGroups, _, err = client.Group.ListGroups(ctx, &query.Params{
+			Limit:  int64(p.cfg.batchSize),
+			Filter: filter,
+		})
 		if err != nil {
-			return nil, fmt.Errorf("okta: error querying for groups: %w", err)
+			return fmt.Errorf("error querying changed groups: %w", err)
 		}
-
-		users = append(users, out...)
-		usersURL = getNextLink(hdrs)
 	}
 
-	return users, nil
+	err := p.syncGroups(ctx, client, changedGroups)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
-func (p *Provider) apiGet(ctx context.Context, uri string, out interface{}) (http.Header, error) {
-	apiKey := p.cfg.apiKey
-	if apiKey == "" {
-		return nil, ErrAPIKeyRequired
-	}
+func (p *Provider) syncGroups(ctx context.Context, client *okta.Client, groups []*okta.Group) error {
+	for _, g := range groups {
+		p.groups[g.Id] = *g
 
-	req, err := http.NewRequestWithContext(ctx, "GET", uri, nil)
-	if err != nil {
-		return nil, fmt.Errorf("okta: failed to create HTTP request: %w", err)
-	}
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "SSWS "+apiKey)
-
-	for {
-		res, err := p.cfg.getHTTPClient().Do(req)
+		users, _, err := client.Group.ListGroupUsers(ctx, g.Id, &query.Params{
+			Limit: int64(p.cfg.batchSize),
+		})
 		if err != nil {
-			return nil, err
+			return fmt.Errorf("error listing group members: %w", err)
 		}
-		defer res.Body.Close()
-
-		if res.StatusCode == http.StatusTooManyRequests {
-			limitReset, err := strconv.ParseInt(res.Header.Get("X-Rate-Limit-Reset"), 10, 64)
-			if err == nil {
-				time.Sleep(time.Until(time.Unix(limitReset, 0)))
-			}
-			continue
+		s := make([]okta.User, len(users))
+		for i, u := range users {
+			s[i] = *u
 		}
-		if res.StatusCode/100 != httpSuccessClass {
-			return nil, newAPIError(res)
-		}
-		if err := json.NewDecoder(res.Body).Decode(out); err != nil {
-			return nil, err
-		}
-		return res.Header, nil
+		p.groupMembers[g.Id] = s
 	}
+
+	return nil
 }
 
-func (p *Provider) getURL(path string, modifyQuery func(url.Values)) (string, error) {
-	if p.cfg.url == "" {
-		return "", ErrInvalidURL
+func getUserDisplayName(user *okta.User) string {
+	if user == nil || user.Profile == nil {
+		return ""
 	}
 
-	u, err := url.Parse(p.cfg.url)
-	if err != nil {
-		return "", ErrInvalidURL
-	}
-	q := u.Query()
-	modifyQuery(q)
-	u = u.ResolveReference(&url.URL{
-		Path:     path,
-		RawQuery: q.Encode(),
-	})
-	return u.String(), nil
+	firstName, _ := (*user.Profile)["firstName"].(string)
+	lastName, _ := (*user.Profile)["lastName"].(string)
+	return firstName + " " + lastName
 }
 
-func getNextLink(hdrs http.Header) string {
-	for _, link := range linkheader.ParseMultiple(hdrs.Values("Link")) {
-		if link.Rel == "next" {
-			return link.URL
-		}
+func getUserEmail(user *okta.User) string {
+	if user == nil || user.Profile == nil {
+		return ""
 	}
-	return ""
-}
 
-// An APIError is an error from the okta API.
-type APIError struct {
-	HTTPStatusCode int
-	Body           string
-	ErrorCode      string   `json:"errorCode"`
-	ErrorSummary   string   `json:"errorSummary"`
-	ErrorLink      string   `json:"errorLink"`
-	ErrorID        string   `json:"errorId"`
-	ErrorCauses    []string `json:"errorCauses"`
-}
-
-func newAPIError(res *http.Response) error {
-	if res == nil {
-		return nil
+	email, ok := (*user.Profile)["email"].(string)
+	if !ok {
+		return ""
 	}
-	buf, _ := io.ReadAll(io.LimitReader(res.Body, readLimit)) // limit to 100kb
 
-	err := &APIError{
-		HTTPStatusCode: res.StatusCode,
-		Body:           string(buf),
-	}
-	_ = json.Unmarshal(buf, err)
-	return err
-}
-
-func (err *APIError) Error() string {
-	return fmt.Sprintf("okta: error querying API, status_code=%d: %s", err.HTTPStatusCode, err.Body)
-}
-
-type (
-	apiGroupObject struct {
-		ID      string `json:"id"`
-		Profile struct {
-			Name string `json:"name"`
-		} `json:"profile"`
-		LastUpdated           string `json:"lastUpdated"`
-		LastMembershipUpdated string `json:"lastMembershipUpdated"`
-	}
-	apiUserObject struct {
-		ID      string `json:"id"`
-		Profile struct {
-			FirstName string `json:"firstName"`
-			LastName  string `json:"lastName"`
-			Email     string `json:"email"`
-		} `json:"profile"`
-	}
-)
-
-func (obj *apiUserObject) getDisplayName() string {
-	return obj.Profile.FirstName + " " + obj.Profile.LastName
+	return email
 }

--- a/pkg/directory/okta/provider.go
+++ b/pkg/directory/okta/provider.go
@@ -96,8 +96,8 @@ func (p *Provider) sync(ctx context.Context, client *okta.Client) error {
 	var changedGroups []*okta.Group
 	if lastMembershipUpdated.IsZero() || lastUpdated.IsZero() {
 		// full sync
-		p.groups = make(map[string]okta.Group)
-		p.groupMembers = make(map[string][]okta.User)
+		clear(p.groups)
+		clear(p.groupMembers)
 
 		var err error
 		changedGroups, _, err = client.Group.ListGroups(ctx, &query.Params{

--- a/pkg/directory/okta/provider.go
+++ b/pkg/directory/okta/provider.go
@@ -33,7 +33,7 @@ func New(options ...Option) *Provider {
 	}
 }
 
-// GetDirectory get's the full directory information for Okta.
+// GetDirectory gets the full directory information for Okta.
 func (p *Provider) GetDirectory(ctx context.Context) ([]directory.Group, []directory.User, error) {
 	ctx, client, err := okta.NewClient(ctx,
 		okta.WithHttpClientPtr(p.cfg.getHTTPClient()),

--- a/pkg/directory/okta/provider.go
+++ b/pkg/directory/okta/provider.go
@@ -36,10 +36,11 @@ func New(options ...Option) *Provider {
 // GetDirectory gets the full directory information for Okta.
 func (p *Provider) GetDirectory(ctx context.Context) ([]directory.Group, []directory.User, error) {
 	ctx, client, err := okta.NewClient(ctx,
-		okta.WithHttpClientPtr(p.cfg.getHTTPClient()),
-		okta.WithOrgUrl(p.cfg.url),
-		okta.WithTestingDisableHttpsCheck(true),
-		okta.WithToken(p.cfg.apiKey))
+		append([]okta.ConfigSetter{
+			okta.WithHttpClientPtr(p.cfg.getHTTPClient()),
+			okta.WithOrgUrl(p.cfg.url),
+			okta.WithToken(p.cfg.apiKey),
+		}, p.cfg.oktaOptions...)...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating okta client: %w", err)
 	}


### PR DESCRIPTION
## Summary
Refactor the okta directory provider.

* Add the `url` parameter to the `cmd`. It didn't work without this. (for testing outside of the enterprise console)
* Fix the `filterDateFormat`. The sub seconds is required, hence using `.000Z` instead of `.999Z`.
* Switch to the Okta SDK which has built-in support for paging and rate limiting.
* Fix the way groups are synchronized after initial synchronization to only sync changes (for #342)

## Related issues
- #342 


## Checklist
- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
