### PR TITLE
datasource/wellknownips: fix aws test

### DIFF
--- a/internal/wellknownips/amazonaws.go
+++ b/internal/wellknownips/amazonaws.go
@@ -7,12 +7,14 @@ import (
 )
 
 type AmazonAWSIPRanges struct {
-	Prefixes []struct {
-		IPPrefix           string `json:"ip_prefix"`
-		Region             string `json:"region"`
-		Service            string `json:"service"`
-		NetworkBorderGroup string `json:"network_border_group"`
-	} `json:"prefixes"`
+	Prefixes []AmazonAWSIPRangePrefix `json:"prefixes"`
+}
+
+type AmazonAWSIPRangePrefix struct {
+	IPPrefix           string `json:"ip_prefix"`
+	Region             string `json:"region"`
+	Service            string `json:"service"`
+	NetworkBorderGroup string `json:"network_border_group"`
 }
 
 // DefaultAmazonAWSIPRangesURL is the default amazon aws ip ranges url.

--- a/internal/wellknownips/amazonaws_test.go
+++ b/internal/wellknownips/amazonaws_test.go
@@ -3,6 +3,7 @@ package wellknownips
 import (
 	"context"
 	"net/http"
+	"slices"
 	"testing"
 	"time"
 
@@ -20,6 +21,8 @@ func TestFetchAmazonAWSIPRanges(t *testing.T) {
 	ranges, err := FetchAmazonAWSIPRanges(ctx, client, DefaultAmazonAWSIPRangesURL)
 	assert.NoError(t, err)
 	if assert.NotNil(t, ranges) && assert.Greater(t, len(ranges.Prefixes), 0) {
-		assert.Equal(t, "3.5.140.0/22", ranges.Prefixes[0].IPPrefix)
+		assert.True(t, slices.ContainsFunc(ranges.Prefixes, func(p AmazonAWSIPRangePrefix) bool {
+			return p.IPPrefix == "3.5.140.0/22"
+		}))
 	}
 }


### PR DESCRIPTION
## Summary
It looks like the AWS well known IPs changed. Updated the test to be more tolerant of ordering.

## Related issues
- https://github.com/pomerium/datasource/pull/357


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
