### PR TITLE
datasource/ci: update lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,10 +17,10 @@ jobs:
 
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
           cache: false
 
       - uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86
         with:
-          version: v1.55
+          version: v1.60.1
           args: --timeout=10m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,6 @@ linters:
     - errcheck
     - errname
     - errorlint
-    - execinquery
     - exhaustive
     - gci
     - goconst

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.22.0
+golang 1.23.0

--- a/cmd/pomerium-datasource/directory.go
+++ b/cmd/pomerium-datasource/directory.go
@@ -162,7 +162,7 @@ func directorySubCommand(
 	cmd.Flags().StringVar(&addr, "address", ":8080", "tcp address to listen to")
 	cmd.Flags().BoolVar(&debug, "debug", false, "debug mode")
 	newProvider := setupFlags(cmd.Flags())
-	cmd.Run = func(cmd *cobra.Command, args []string) {
+	cmd.Run = func(cmd *cobra.Command, _ []string) {
 		if debug {
 			zerolog.SetGlobalLevel(zerolog.DebugLevel)
 		}

--- a/cmd/pomerium-datasource/ip2location.go
+++ b/cmd/pomerium-datasource/ip2location.go
@@ -19,14 +19,14 @@ var ip2LocationCmd = &cobra.Command{
 	Use:   "ip2location <file>",
 	Short: "runs the IP2Location server",
 	Args:  cobra.ExactArgs(1),
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+	PersistentPreRunE: func(_ *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			return fmt.Errorf("file is required")
 		}
 		ip2LocationArgs.file = args[0]
 		return nil
 	},
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		log.Info().
 			Str("address", ip2LocationArgs.address).
 			Str("file", ip2LocationArgs.file).

--- a/cmd/pomerium-datasource/wellknownips.go
+++ b/cmd/pomerium-datasource/wellknownips.go
@@ -16,7 +16,7 @@ var wellKnownIPsArgs struct {
 var wellKnownIPsCmd = &cobra.Command{
 	Use:   "well-known-ips",
 	Short: "runs the well known ips server",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		log.Info().
 			Str("address", wellKnownIPsArgs.address).
 			Str("ip2asn-url", wellKnownIPsArgs.ip2asnURL).

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,7 +12,7 @@ import (
 func RunHTTPServer(ctx context.Context, addr string, handler http.Handler) error {
 	srv := http.Server{
 		Addr: addr,
-		BaseContext: func(l net.Listener) context.Context {
+		BaseContext: func(_ net.Listener) context.Context {
 			return ctx
 		},
 		Handler:           handler,

--- a/internal/util/mapstructure.go
+++ b/internal/util/mapstructure.go
@@ -53,7 +53,7 @@ func NewDateTime(tm time.Time, layout string) DateTime {
 // DateTimeDecodeHook parses date time that's supplied in a non-standard layout
 // if layout does not contain a time zone, a location need be provided
 func DateTimeDecodeHook(layout string, location *time.Location) mapstructure.DecodeHookFuncType {
-	return func(srcT, dstT reflect.Type, data interface{}) (interface{}, error) {
+	return func(_, dstT reflect.Type, data interface{}) (interface{}, error) {
 		if dstT != DateType {
 			return data, nil
 		}

--- a/internal/zenefits/api_test.go
+++ b/internal/zenefits/api_test.go
@@ -68,7 +68,7 @@ func TestAPI(t *testing.T) {
 }
 
 func serveJSON(p string, statusCode int) func(w http.ResponseWriter, r *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, _ *http.Request) {
 		data, err := os.ReadFile(p)
 		if err != nil {
 			w.WriteHeader(http.StatusNotFound)

--- a/pkg/directory/azure/azure_test.go
+++ b/pkg/directory/azure/azure_test.go
@@ -51,7 +51,7 @@ func newMockAPI(t *testing.T, _ *httptest.Server) http.Handler {
 				}
 			})
 		})
-		r.Get("/groups/delta", func(w http.ResponseWriter, r *http.Request) {
+		r.Get("/groups/delta", func(w http.ResponseWriter, _ *http.Request) {
 			_ = json.NewEncoder(w).Encode(M{
 				"value": []M{
 					{
@@ -73,7 +73,7 @@ func newMockAPI(t *testing.T, _ *httptest.Server) http.Handler {
 				},
 			})
 		})
-		r.Get("/users/delta", func(w http.ResponseWriter, r *http.Request) {
+		r.Get("/users/delta", func(w http.ResponseWriter, _ *http.Request) {
 			_ = json.NewEncoder(w).Encode(M{
 				"value": []M{
 					{"id": "user-1", "displayName": "User 1", "mail": "user1@example.com"},

--- a/pkg/directory/github/github_test.go
+++ b/pkg/directory/github/github_test.go
@@ -89,7 +89,7 @@ func newMockAPI(t *testing.T, _ *httptest.Server) http.Handler {
 
 			result.Data.Organization.MembersWithRole = membersWithRole
 		}
-		handleTeamMembers := func(orgSlug, teamSlug string, field *ast.Field) {
+		handleTeamMembers := func(_, teamSlug string, _ *ast.Field) {
 			result.Data.Organization.Team.Members = &qlTeamMemberConnection{
 				PageInfo: qlPageInfo{HasNextPage: false},
 			}
@@ -272,7 +272,7 @@ func newMockAPI(t *testing.T, _ *httptest.Server) http.Handler {
 
 		_ = json.NewEncoder(w).Encode(result)
 	})
-	r.Get("/user/orgs", func(w http.ResponseWriter, r *http.Request) {
+	r.Get("/user/orgs", func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode([]M{
 			{"login": "org1"},
 			{"login": "org2"},

--- a/pkg/directory/gitlab/gitlab_test.go
+++ b/pkg/directory/gitlab/gitlab_test.go
@@ -32,7 +32,7 @@ func newMockAPI(t *testing.T, _ *httptest.Server) http.Handler {
 				next.ServeHTTP(w, r)
 			})
 		})
-		r.Get("/groups", func(w http.ResponseWriter, r *http.Request) {
+		r.Get("/groups", func(w http.ResponseWriter, _ *http.Request) {
 			_ = json.NewEncoder(w).Encode([]M{
 				{"id": 1, "name": "Group 1"},
 				{"id": 2, "name": "Group 2"},

--- a/pkg/directory/google/google_test.go
+++ b/pkg/directory/google/google_test.go
@@ -64,7 +64,7 @@ func newMockAPI(t *testing.T, _ *httptest.Server) http.Handler {
 
 	r := chi.NewRouter()
 	r.Use(middleware.Logger)
-	r.Post("/token", func(w http.ResponseWriter, r *http.Request) {
+	r.Post("/token", func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(M{
 			"access_token":  "ACCESSTOKEN",
 			"token_type":    "Bearer",
@@ -116,7 +116,7 @@ func newMockAPI(t *testing.T, _ *httptest.Server) http.Handler {
 			})
 		})
 		r.Route("/users", func(r chi.Router) {
-			r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+			r.Get("/", func(w http.ResponseWriter, _ *http.Request) {
 				_ = json.NewEncoder(w).Encode(M{
 					"kind": "admin#directory#users",
 					"users": []M{

--- a/pkg/directory/http_test.go
+++ b/pkg/directory/http_test.go
@@ -27,7 +27,7 @@ func TestHandler(t *testing.T) {
 			users  []User
 			err    error
 		}{}
-		h := NewHandler(ProviderFunc(func(ctx context.Context) ([]Group, []User, error) {
+		h := NewHandler(ProviderFunc(func(_ context.Context) ([]Group, []User, error) {
 			return expect.groups, expect.users, expect.err
 		}))
 		srv := httptest.NewServer(h)
@@ -80,7 +80,7 @@ func TestHandler(t *testing.T) {
 			users  []User
 			err    error
 		}{}
-		h := NewHandler(ProviderFunc(func(ctx context.Context) ([]Group, []User, error) {
+		h := NewHandler(ProviderFunc(func(_ context.Context) ([]Group, []User, error) {
 			return expect.groups, expect.users, expect.err
 		}))
 		srv := httptest.NewServer(h)

--- a/pkg/directory/onelogin/onelogin_test.go
+++ b/pkg/directory/onelogin/onelogin_test.go
@@ -125,7 +125,7 @@ func newMockAPI(srv *httptest.Server, userIDToGroupName map[int]string) http.Han
 				}},
 			})
 		})
-		r.Get("/users", func(w http.ResponseWriter, r *http.Request) {
+		r.Get("/users", func(w http.ResponseWriter, _ *http.Request) {
 			userIDToGroupID := map[int]int{}
 			for userID, groupName := range userIDToGroupName {
 				for id, n := range allGroups {

--- a/pkg/directory/ping/config.go
+++ b/pkg/directory/ping/config.go
@@ -77,11 +77,11 @@ func WithLogger(logger zerolog.Logger) Option {
 func WithProviderURL(providerURL *url.URL) Option {
 	// provider URL will be https://auth.pingone.com/{ENVIRONMENT_ID}/as
 	if providerURL == nil {
-		return func(cfg *config) {}
+		return func(_ *config) {}
 	}
 	parts := strings.Split(providerURL.Path, "/")
 	if len(parts) < 1 {
-		return func(cfg *config) {}
+		return func(_ *config) {}
 	}
 	return WithEnvironmentID(parts[1])
 }

--- a/pkg/directory/ping/ping_test.go
+++ b/pkg/directory/ping/ping_test.go
@@ -73,7 +73,7 @@ func newMockAPI(userIDToGroupIDs map[string][]string) http.Handler {
 		})
 	})
 	r.Route("/v1/environments/ENVIRONMENTID", func(r chi.Router) {
-		r.Get("/groups", func(w http.ResponseWriter, r *http.Request) {
+		r.Get("/groups", func(w http.ResponseWriter, _ *http.Request) {
 			var apiGroups []apiGroup
 			for _, id := range allGroups {
 				apiGroups = append(apiGroups, apiGroup{


### PR DESCRIPTION
For https://github.com/pomerium/internal/issues/1835

Update golangci-lint to v1.60.1