### PR TITLE
json: add streaming json reader

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,5 +22,5 @@ jobs:
 
       - uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86
         with:
-          version: v1.60.1
+          version: v1.61.0
           args: --timeout=10m

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ snapshot: ## Create release snapshot
 lint:
 	@echo "@==> $@"
 	@VERSION=$$(go run github.com/mikefarah/yq/v4@v4.34.1 '.jobs.lint.steps[] | select(.uses == "golangci/golangci-lint-action*") | .with.version' .github/workflows/lint.yml) && \
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@$$VERSION run ./...
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@$$VERSION run --fix ./...
 
 .PHONY: help
 help:

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/pomerium/datasource
 
-go 1.22
-toolchain go1.22.5
+go 1.23.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.30.5

--- a/internal/jsonutil/reader.go
+++ b/internal/jsonutil/reader.go
@@ -10,6 +10,7 @@ import (
 
 // StreamArrayReader reads a JSON array from r and yields each element.
 // keys is a list of keys hierarchy to traverse before reading the array.
+// the returned iterator is single-use.
 func StreamArrayReader[T any](r io.Reader, keys []string) iter.Seq2[T, error] {
 	return func(yield func(T, error) bool) {
 		var v T

--- a/internal/jsonutil/reader.go
+++ b/internal/jsonutil/reader.go
@@ -1,0 +1,126 @@
+package jsonutil
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"iter"
+)
+
+// StreamArrayReader reads a JSON array from r and yields each element.
+func StreamArrayReader[T any](r io.Reader, keys []string) iter.Seq2[T, error] {
+	return func(yield func(T, error) bool) {
+		var v T
+		decoder := json.NewDecoder(r)
+
+		err := traverseKeys(decoder, keys)
+		if err != nil {
+			yield(v, err)
+			return
+		}
+
+		tk, err := decoder.Token()
+		if err != nil {
+			yield(v, fmt.Errorf("reading next token: %w", err))
+			return
+		}
+		if tk != json.Delim('[') {
+			yield(v, fmt.Errorf("expected `[`, got `%v`", tk))
+			return
+		}
+
+		for decoder.More() {
+			err := decoder.Decode(&v)
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			if !yield(v, err) {
+				return
+			}
+			if err != nil {
+				return
+			}
+		}
+
+		tk, err = decoder.Token()
+		if err != nil {
+			yield(v, fmt.Errorf("reading next token: %w", err))
+			return
+		}
+		if tk != json.Delim(']') {
+			yield(v, fmt.Errorf("expected `[`, got `%v`", tk))
+			return
+		}
+	}
+}
+
+func skipObject(decoder *json.Decoder) error {
+	t, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+
+	_, ok := t.(json.Delim)
+	if !ok {
+		return nil
+	}
+
+	for decoder.More() {
+		err := skipObject(decoder)
+		if err != nil {
+			return err
+		}
+	}
+
+	t, err = decoder.Token()
+	if err != nil {
+		return err
+	}
+	_, ok = t.(json.Delim)
+	if !ok {
+		return fmt.Errorf("expected delimeter, got %v", t)
+	}
+
+	return nil
+}
+
+func findObjectKey(decoder *json.Decoder, key string) error {
+	t, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+
+	delim, ok := t.(json.Delim)
+	if !ok || delim != '{' {
+		return fmt.Errorf("expected a {, got %v", t)
+	}
+
+	for {
+		t, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		keyName, ok := t.(string)
+		if !ok {
+			return fmt.Errorf("expected a string key, got %v", t)
+		}
+		if keyName == key {
+			return nil
+		}
+		err = skipObject(decoder)
+		if err != nil {
+			return fmt.Errorf("error skipping object for key %s: %w", keyName, err)
+		}
+	}
+}
+
+func traverseKeys(decoder *json.Decoder, keys []string) error {
+	for _, key := range keys {
+		err := findObjectKey(decoder, key)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/jsonutil/reader.go
+++ b/internal/jsonutil/reader.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-
 	"iter"
 )
 

--- a/internal/jsonutil/reader_test.go
+++ b/internal/jsonutil/reader_test.go
@@ -3,12 +3,13 @@ package jsonutil_test
 import (
 	"encoding/json"
 	"io"
-	"iter"
 	"strings"
 	"testing"
 
-	"github.com/pomerium/datasource/internal/jsonutil"
 	"github.com/stretchr/testify/require"
+	"iter"
+
+	"github.com/pomerium/datasource/internal/jsonutil"
 )
 
 func collect[T any](it iter.Seq2[T, error]) ([]T, error) {
@@ -51,12 +52,14 @@ func mkTest[T any](
 }
 
 func TestReader(t *testing.T) {
+	t.Parallel()
+
 	type S struct {
 		A int
 		B string
 	}
 
-	var ts []S = []S{
+	ts := []S{
 		{1, "a"},
 		{2, "b"},
 		{3, "c"},
@@ -84,6 +87,8 @@ func TestReader(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			encoded, err := json.Marshal(tc.input)
 			require.NoError(t, err)
 

--- a/internal/jsonutil/reader_test.go
+++ b/internal/jsonutil/reader_test.go
@@ -3,11 +3,11 @@ package jsonutil_test
 import (
 	"encoding/json"
 	"io"
+	"iter"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"iter"
 
 	"github.com/pomerium/datasource/internal/jsonutil"
 )

--- a/internal/jsonutil/reader_test.go
+++ b/internal/jsonutil/reader_test.go
@@ -1,0 +1,95 @@
+package jsonutil_test
+
+import (
+	"encoding/json"
+	"io"
+	"iter"
+	"strings"
+	"testing"
+
+	"github.com/pomerium/datasource/internal/jsonutil"
+	"github.com/stretchr/testify/require"
+)
+
+func collect[T any](it iter.Seq2[T, error]) ([]T, error) {
+	var result []T
+	for v, err := range it {
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, v)
+	}
+	return result, nil
+}
+
+type testCase struct {
+	name     string
+	input    any
+	expected any
+	fn       func(r io.Reader) (any, error)
+}
+
+func mkTest[T any](
+	name string,
+	input any,
+	expected any,
+	keys []string,
+) testCase {
+	return testCase{
+		name:     name + " " + strings.Join(keys, "."),
+		input:    input,
+		expected: expected,
+		fn: func(r io.Reader) (any, error) {
+			it := jsonutil.StreamArrayReader[T](r, keys)
+			result, err := collect(it)
+			if err != nil {
+				return nil, err
+			}
+			return result, nil
+		},
+	}
+}
+
+func TestReader(t *testing.T) {
+	type S struct {
+		A int
+		B string
+	}
+
+	var ts []S = []S{
+		{1, "a"},
+		{2, "b"},
+		{3, "c"},
+	}
+
+	tests := []testCase{
+		mkTest[int]("int", []int{1, 2, 3}, []int{1, 2, 3}, nil),
+		mkTest[string]("string", []string{"a", "b", "c"}, []string{"a", "b", "c"}, nil),
+		mkTest[S]("struct", ts, ts, nil),
+		mkTest[int]("int", map[string]any{"nested": []int{1, 2, 3}}, []int{1, 2, 3}, []string{"nested"}),
+		mkTest[int]("int", map[string]any{"nested": map[string]any{"two-level": []int{1, 2, 3}}}, []int{1, 2, 3}, []string{"nested", "two-level"}),
+		mkTest[int]("int", map[string]any{
+			"j1": []int{4, 5, 6},
+			"j2": "v",
+			"j3": map[string]any{
+				"j4": []int{4, 5, 6},
+			},
+			"key1": map[string]any{
+				"j5":              []int{4, 5, 6},
+				"j6":              "v2",
+				"with-other-keys": []int{1, 2, 3},
+			},
+		}, []int{1, 2, 3}, []string{"key1", "with-other-keys"}),
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded, err := json.Marshal(tc.input)
+			require.NoError(t, err)
+
+			result, err := tc.fn(strings.NewReader(string(encoded)))
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Sometimes we need to transpose a large JSON array of objects, returned from another API, and reading all data in memory may not be reasonable as there may be tens of thousands of entries. 

This PR adds a `jsonutil.StreamArrayReader` that can traverse to the desired nested json object array and sequentially decode the values. 

## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
