### PR TITLE
fleet: ignore missing key

### DIFF
--- a/cmd/pomerium-datasource/main.go
+++ b/cmd/pomerium-datasource/main.go
@@ -37,6 +37,7 @@ func main() {
 func makeLogger() zerolog.Logger {
 	logger := zerolog.New(zerolog.NewConsoleWriter())
 	log.Logger = logger
+	zerolog.DefaultContextLogger = &logger
 	return logger
 }
 

--- a/internal/jsonutil/reader_test.go
+++ b/internal/jsonutil/reader_test.go
@@ -98,3 +98,27 @@ func TestReader(t *testing.T) {
 		})
 	}
 }
+
+func TestReaderError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		encoded       string
+		keys          []string
+		expectedError error
+	}{
+		{"nokey 1", `{"k2":{}}`, []string{"k1"}, jsonutil.ErrKeyNotFound},
+		{"empty 1", `{}`, []string{"key"}, jsonutil.ErrKeyNotFound},
+		{"empty 2", `{"k1":{"k3":{"k4":1}}}`, []string{"k1", "k2"}, jsonutil.ErrKeyNotFound},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := collect(jsonutil.StreamArrayReader[int](strings.NewReader(tc.encoded), tc.keys))
+			require.ErrorIs(t, err, tc.expectedError)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

For brand new setups, Fleet server may omit keys and return `{}` instead of expected `{"policies":[]}`. 

## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
