### PR TITLE
directory: add keycloak provider

### DIFF
--- a/cmd/pomerium-datasource/directory.go
+++ b/cmd/pomerium-datasource/directory.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pomerium/datasource/pkg/directory/github"
 	"github.com/pomerium/datasource/pkg/directory/gitlab"
 	"github.com/pomerium/datasource/pkg/directory/google"
+	"github.com/pomerium/datasource/pkg/directory/keycloak"
 	"github.com/pomerium/datasource/pkg/directory/okta"
 	"github.com/pomerium/datasource/pkg/directory/onelogin"
 	"github.com/pomerium/datasource/pkg/directory/ping"
@@ -103,6 +104,22 @@ func directoryCommand(logger zerolog.Logger) *cobra.Command {
 						google.WithJSONKey(*jsonKey),
 						google.WithJSONKeyFile(*jsonKeyFile),
 						google.WithLogger(logger),
+					)
+				}
+			}),
+		directorySubCommand(logger, "keycloak",
+			func(flags *pflag.FlagSet) func() directory.Provider {
+				clientID := requiredStringFlag(flags, "client-id", "client id")
+				clientSecret := requiredStringFlag(flags, "client-secret", "client secret")
+				realm := requiredStringFlag(flags, "realm", "realm name")
+				url := requiredStringFlag(flags, "url", "url")
+				return func() directory.Provider {
+					return keycloak.New(
+						keycloak.WithClientID(*clientID),
+						keycloak.WithClientSecret(*clientSecret),
+						keycloak.WithRealm(*realm),
+						keycloak.WithLogger(logger),
+						keycloak.WithURL(*url),
 					)
 				}
 			}),

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.57
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.49.3
 	github.com/client9/misspell v0.3.4
+	github.com/coreos/go-oidc/v3 v3.12.0
 	github.com/gabriel-vasile/mimetype v1.4.8
 	github.com/go-chi/chi/v5 v5.2.0
 	github.com/go-playground/validator/v10 v10.24.0
@@ -96,6 +97,7 @@ require (
 	github.com/ghostiam/protogetter v0.3.8 // indirect
 	github.com/go-critic/go-critic v0.11.5 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.4 // indirect
+	github.com/go-jose/go-jose/v4 v4.0.2 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -167,6 +167,8 @@ github.com/ckaznocha/intrange v0.3.0/go.mod h1:+I/o2d2A1FBHgGELbGxzIcyd3/9l9Duwj
 github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/coreos/go-oidc/v3 v3.12.0 h1:sJk+8G2qq94rDI6ehZ71Bol3oUHy63qNYmkiSjrc/Jo=
+github.com/coreos/go-oidc/v3 v3.12.0/go.mod h1:gE3LgjOgFoHi9a4ce4/tJczr0Ai2/BoDhf0r5lltWI0=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/curioswitch/go-reassign v0.3.0 h1:dh3kpQHuADL3cobV/sSGETA8DOv457dwl+fbBAhrQPs=
@@ -214,6 +216,8 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-jose/go-jose/v3 v3.0.4 h1:Wp5HA7bLQcKnf6YYao/4kpRpVMp/yf6+pJKV8WFSaNY=
 github.com/go-jose/go-jose/v3 v3.0.4/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
+github.com/go-jose/go-jose/v4 v4.0.2 h1:R3l3kkBds16bO7ZFAEEcofK0MkrAJt3jlJznWZG0nvk=
+github.com/go-jose/go-jose/v4 v4.0.2/go.mod h1:WVf9LFMHh/QVrmqrOfqun0C45tMe3RoiKJMPvgWwLfY=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=

--- a/pkg/directory/keycloak/config.go
+++ b/pkg/directory/keycloak/config.go
@@ -1,0 +1,104 @@
+package keycloak
+
+import (
+	"crypto/tls"
+	"net/http"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+
+	"github.com/pomerium/datasource/internal/httputil"
+)
+
+const (
+	// DefaultBatchSize is the default batch size for querying groups and users.
+	DefaultBatchSize = 100
+	// DefaultRealm is the default realm if one is not provided.
+	DefaultRealm = "master"
+)
+
+type config struct {
+	batchSize    int
+	httpClient   *http.Client
+	clientID     string
+	clientSecret string
+	logger       zerolog.Logger
+	realm        string
+	url          string
+}
+
+// An Option configures the Keycloak Provider.
+type Option func(cfg *config)
+
+// WithBatchSize sets the batch size in the config.
+func WithBatchSize(batchSize int) Option {
+	return func(cfg *config) {
+		cfg.batchSize = batchSize
+	}
+}
+
+// WithClientID sets the client id in the config.
+func WithClientID(clientID string) Option {
+	return func(cfg *config) {
+		cfg.clientID = clientID
+	}
+}
+
+// WithClientSecret sets the client secret in the config.
+func WithClientSecret(clientSecret string) Option {
+	return func(cfg *config) {
+		cfg.clientSecret = clientSecret
+	}
+}
+
+// WithRealm sets the realm in the config.
+func WithRealm(realm string) Option {
+	return func(cfg *config) {
+		cfg.realm = realm
+	}
+}
+
+// WithHTTPClient sets the http client in the config.
+func WithHTTPClient(httpClient *http.Client) Option {
+	return func(cfg *config) {
+		cfg.httpClient = httpClient
+	}
+}
+
+// WithLogger sets the logger in the config.
+func WithLogger(logger zerolog.Logger) Option {
+	return func(cfg *config) {
+		cfg.logger = logger
+	}
+}
+
+// WithURL sets the url in the config. URL should be the base url without /realms/master.
+func WithURL(url string) Option {
+	return func(cfg *config) {
+		cfg.url = url
+	}
+}
+
+func getConfig(options ...Option) *config {
+	cfg := new(config)
+	WithBatchSize(DefaultBatchSize)(cfg)
+	WithHTTPClient(&http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	})(cfg)
+	WithLogger(log.Logger)(cfg)
+	WithRealm(DefaultRealm)(cfg)
+	for _, option := range options {
+		option(cfg)
+	}
+	return cfg
+}
+
+func (cfg *config) getHTTPClient() *http.Client {
+	return httputil.NewLoggingClient(cfg.logger, cfg.httpClient, func(event *zerolog.Event) *zerolog.Event {
+		return event.Str("idp", "keycloak")
+	})
+}

--- a/pkg/directory/keycloak/config.go
+++ b/pkg/directory/keycloak/config.go
@@ -1,7 +1,6 @@
 package keycloak
 
 import (
-	"crypto/tls"
 	"net/http"
 
 	"github.com/rs/zerolog"
@@ -82,13 +81,7 @@ func WithURL(url string) Option {
 func getConfig(options ...Option) *config {
 	cfg := new(config)
 	WithBatchSize(DefaultBatchSize)(cfg)
-	WithHTTPClient(&http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
-			},
-		},
-	})(cfg)
+	WithHTTPClient(http.DefaultClient)(cfg)
 	WithLogger(log.Logger)(cfg)
 	WithRealm(DefaultRealm)(cfg)
 	for _, option := range options {

--- a/pkg/directory/keycloak/keycloak.go
+++ b/pkg/directory/keycloak/keycloak.go
@@ -1,0 +1,122 @@
+// Package keycloak contains a Keycloak directory provider.
+package keycloak
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/pomerium/datasource/internal/jsonutil"
+)
+
+type apiGroup struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type apiUser struct {
+	ID            string `json:"id"`
+	Username      string `json:"username"`
+	Email         string `json:"email"`
+	EmailVerified bool   `json:"emailVerified"`
+}
+
+func listGroups(
+	ctx context.Context,
+	client *http.Client,
+	baseURL string,
+	realm string,
+	batchSize int,
+) iter.Seq2[apiGroup, error] {
+	apiURL := joinURL(baseURL, "/admin/realms/"+url.PathEscape(realm)+"/groups")
+	return list[apiGroup](ctx, client, apiURL, batchSize)
+}
+
+func listGroupMembers(
+	ctx context.Context,
+	client *http.Client,
+	baseURL string,
+	realm string,
+	groupID string,
+	batchSize int,
+) iter.Seq2[apiUser, error] {
+	apiURL := joinURL(baseURL, "/admin/realms/"+url.PathEscape(realm)+"/groups/"+url.PathEscape(groupID)+"/members")
+	return list[apiUser](ctx, client, apiURL, batchSize)
+}
+
+func listUsers(
+	ctx context.Context,
+	client *http.Client,
+	baseURL string,
+	realm string,
+	batchSize int,
+) iter.Seq2[apiUser, error] {
+	apiURL := joinURL(baseURL, "/admin/realms/"+url.PathEscape(realm)+"/users")
+	return list[apiUser](ctx, client, apiURL, batchSize)
+}
+
+func list[T any](
+	ctx context.Context,
+	client *http.Client,
+	apiURL string,
+	batchSize int,
+) iter.Seq2[T, error] {
+	return func(yield func(T, error) bool) {
+		var def T
+
+		apiURL, err := url.Parse(apiURL)
+		if err != nil {
+			yield(def, err)
+			return
+		}
+
+		for i := 0; ; i += batchSize {
+			apiURL = apiURL.ResolveReference(&url.URL{
+				RawQuery: url.Values{
+					"first": {strconv.Itoa(i)},
+					"max":   {strconv.Itoa(batchSize)},
+				}.Encode(),
+			})
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL.String(), nil)
+			if err != nil {
+				yield(def, fmt.Errorf("error creating api http request: %w", err))
+				return
+			}
+			req.Header.Set("Accept", "application/json")
+
+			res, err := client.Do(req)
+			if err != nil {
+				yield(def, fmt.Errorf("error making api http request: %w", err))
+				return
+			}
+			defer res.Body.Close()
+
+			if res.StatusCode/100 != 2 {
+				yield(def, fmt.Errorf("error listing, unexpected status code %d", res.StatusCode))
+				return
+			}
+
+			cnt := 0
+			for v, err := range jsonutil.StreamArrayReader[T](res.Body, nil) {
+				if err != nil {
+					yield(v, err)
+					return
+				}
+
+				if !yield(v, err) {
+					return
+				}
+
+				cnt++
+			}
+
+			if cnt < batchSize {
+				break
+			}
+		}
+	}
+}

--- a/pkg/directory/keycloak/keycloak_test.go
+++ b/pkg/directory/keycloak/keycloak_test.go
@@ -1,0 +1,137 @@
+package keycloak_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/datasource/pkg/directory"
+	"github.com/pomerium/datasource/pkg/directory/keycloak"
+)
+
+type (
+	A = []any
+	M = map[string]any
+)
+
+func newMockAPI(t *testing.T, srv *httptest.Server) http.Handler {
+	t.Helper()
+
+	groups := A{
+		M{"id": "g1", "name": "group-1"},
+		M{"id": "g2", "name": "group-2"},
+		M{"id": "g3", "name": "group-3"},
+		M{"id": "g4", "name": "group-4"},
+		M{"id": "g5", "name": "group-5"},
+	}
+	users := A{
+		M{"id": "u1", "email": "u1@example.com", "emailVerified": true, "username": "user-1"},
+		M{"id": "u2", "email": "u2@example.com", "emailVerified": true, "username": "user-2"},
+		M{"id": "u3", "email": "u3@example.com", "emailVerified": true, "username": "user-3"},
+		M{"id": "u4", "email": "u4@example.com", "username": "user-4"},
+	}
+	lookup := map[string]A{
+		"g1": {M{"id": "u1"}, M{"id": "u2"}},
+		"g2": {M{"id": "u3"}},
+		"g3": {M{"id": "u1"}, M{"id": "u2"}, M{"id": "u3"}},
+	}
+
+	sendList := func(w http.ResponseWriter, r *http.Request, lst A) {
+		o, err := strconv.Atoi(r.FormValue("first"))
+		require.NoError(t, err)
+		sz, err := strconv.Atoi(r.FormValue("max"))
+		require.NoError(t, err)
+		next := lst[o:]
+		next = next[:min(len(next), sz)]
+		w.Header().Set("Content-Type", "application/json")
+		if next == nil {
+			next = A{}
+		}
+		_ = json.NewEncoder(w).Encode(next)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /realms/REALM/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(M{
+			"issuer":         srv.URL + "/realms/REALM",
+			"token_endpoint": srv.URL + "/realms/REALM/protocol/openid-connect/token",
+		})
+	})
+	mux.HandleFunc("POST /realms/REALM/protocol/openid-connect/token", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "CLIENT_ID", r.FormValue("client_id"))
+		assert.Equal(t, "CLIENT_SECRET", r.FormValue("client_secret"))
+		assert.Equal(t, "client_credentials", r.FormValue("grant_type"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(M{
+			"access_token": "ACCESS_TOKEN",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	})
+	mux.HandleFunc("GET /admin/realms/REALM/groups", func(w http.ResponseWriter, r *http.Request) {
+		sendList(w, r, groups)
+	})
+	mux.HandleFunc("GET /admin/realms/REALM/groups/g1/members", func(w http.ResponseWriter, r *http.Request) {
+		sendList(w, r, lookup["g1"])
+	})
+	mux.HandleFunc("GET /admin/realms/REALM/groups/g2/members", func(w http.ResponseWriter, r *http.Request) {
+		sendList(w, r, lookup["g2"])
+	})
+	mux.HandleFunc("GET /admin/realms/REALM/groups/g3/members", func(w http.ResponseWriter, r *http.Request) {
+		sendList(w, r, lookup["g3"])
+	})
+	mux.HandleFunc("GET /admin/realms/REALM/groups/g4/members", func(w http.ResponseWriter, r *http.Request) {
+		sendList(w, r, lookup["g4"])
+	})
+	mux.HandleFunc("GET /admin/realms/REALM/groups/g5/members", func(w http.ResponseWriter, r *http.Request) {
+		sendList(w, r, lookup["g5"])
+	})
+	mux.HandleFunc("GET /admin/realms/REALM/users", func(w http.ResponseWriter, r *http.Request) {
+		sendList(w, r, users)
+	})
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Log(r.Method, r.URL.String())
+		mux.ServeHTTP(w, r)
+	})
+}
+
+func TestKeyCloak(t *testing.T) {
+	t.Parallel()
+
+	var mockAPI http.Handler
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mockAPI.ServeHTTP(w, r)
+	}))
+	defer srv.Close()
+	mockAPI = newMockAPI(t, srv)
+
+	k := keycloak.New(
+		keycloak.WithBatchSize(3),
+		keycloak.WithClientID("CLIENT_ID"),
+		keycloak.WithClientSecret("CLIENT_SECRET"),
+		keycloak.WithRealm("REALM"),
+		keycloak.WithURL(srv.URL),
+	)
+	dgs, dus, err := k.GetDirectory(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, []directory.Group{
+		{ID: "g1", Name: "group-1"},
+		{ID: "g2", Name: "group-2"},
+		{ID: "g3", Name: "group-3"},
+		{ID: "g4", Name: "group-4"},
+		{ID: "g5", Name: "group-5"},
+	}, dgs)
+	assert.Equal(t, []directory.User{
+		{ID: "u1", DisplayName: "user-1", Email: "u1@example.com", GroupIDs: []string{"g1", "g3"}},
+		{ID: "u2", DisplayName: "user-2", Email: "u2@example.com", GroupIDs: []string{"g1", "g3"}},
+		{ID: "u3", DisplayName: "user-3", Email: "u3@example.com", GroupIDs: []string{"g2", "g3"}},
+		{ID: "u4", DisplayName: "user-4"},
+	}, dus)
+}

--- a/pkg/directory/keycloak/provider.go
+++ b/pkg/directory/keycloak/provider.go
@@ -1,0 +1,135 @@
+package keycloak
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+
+	"github.com/pomerium/datasource/pkg/directory"
+)
+
+// A Provider implements the directory provider interface for Keycloak.
+type Provider struct {
+	cfg *config
+
+	tokenSourceMu sync.Mutex
+	tokenSource   oauth2.TokenSource
+}
+
+// New creates a new provider.
+func New(options ...Option) *Provider {
+	return &Provider{
+		cfg: getConfig(options...),
+	}
+}
+
+// GetDirectory returns the directory information for a Keycloak realm.
+func (p *Provider) GetDirectory(ctx context.Context) ([]directory.Group, []directory.User, error) {
+	client, err := p.getHTTPClient(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var dgs []directory.Group
+	for g, err := range listGroups(ctx, client, p.cfg.url, p.cfg.realm, p.cfg.batchSize) {
+		if err != nil {
+			return nil, nil, err
+		}
+
+		dgs = append(dgs, directory.Group{
+			ID:   g.ID,
+			Name: g.Name,
+		})
+	}
+	slices.SortFunc(dgs, func(dg1, dg2 directory.Group) int {
+		return cmp.Compare(dg1.ID, dg2.ID)
+	})
+
+	groupLookup := map[string][]string{}
+	for _, dg := range dgs {
+		for u, err := range listGroupMembers(ctx, client, p.cfg.url, p.cfg.realm, dg.ID, p.cfg.batchSize) {
+			if err != nil {
+				return nil, nil, err
+			}
+			groupLookup[u.ID] = append(groupLookup[u.ID], dg.ID)
+		}
+	}
+
+	var dus []directory.User
+	for u, err := range listUsers(ctx, client, p.cfg.url, p.cfg.realm, p.cfg.batchSize) {
+		if err != nil {
+			return nil, nil, err
+		}
+
+		email := u.Email
+		if !u.EmailVerified {
+			email = ""
+		}
+		dus = append(dus, directory.User{
+			ID:          u.ID,
+			DisplayName: u.Username,
+			GroupIDs:    groupLookup[u.ID],
+			Email:       email,
+		})
+	}
+	slices.SortFunc(dus, func(du1, du2 directory.User) int {
+		return cmp.Compare(du1.ID, du2.ID)
+	})
+
+	return dgs, dus, nil
+}
+
+func (p *Provider) getHTTPClient(ctx context.Context) (*http.Client, error) {
+	p.tokenSourceMu.Lock()
+	defer p.tokenSourceMu.Unlock()
+
+	if p.cfg.realm == "" {
+		return nil, fmt.Errorf("realm is required")
+	}
+	if p.cfg.clientID == "" {
+		return nil, fmt.Errorf("client id is required")
+	}
+	if p.cfg.clientSecret == "" {
+		return nil, fmt.Errorf("client secret is required")
+	}
+	if p.cfg.url == "" {
+		return nil, fmt.Errorf("url is required")
+	}
+
+	client := p.cfg.getHTTPClient()
+
+	// set up the token source for oauth
+	if p.tokenSource == nil {
+		tokenSourceCtx := context.Background()
+		tokenSourceCtx = oidc.ClientContext(tokenSourceCtx, client)
+
+		oidcProvider, err := oidc.NewProvider(tokenSourceCtx,
+			joinURL(p.cfg.url, "/realms/"+url.PathEscape(p.cfg.realm)))
+		if err != nil {
+			return nil, fmt.Errorf("error creating oidc provider (url=%s): %w", p.cfg.url, err)
+		}
+
+		e := oidcProvider.Endpoint()
+		p.tokenSource = (&clientcredentials.Config{
+			ClientID:     p.cfg.clientID,
+			ClientSecret: p.cfg.clientSecret,
+			TokenURL:     e.TokenURL,
+			AuthStyle:    e.AuthStyle,
+		}).TokenSource(tokenSourceCtx)
+	}
+
+	return oauth2.NewClient(oidc.ClientContext(ctx, client), p.tokenSource), nil
+}
+
+func joinURL(base, path string) string {
+	return strings.TrimSuffix(base, "/") + "/" + strings.TrimPrefix(path, "/")
+}

--- a/pkg/directory/keycloak/provider.go
+++ b/pkg/directory/keycloak/provider.go
@@ -123,7 +123,7 @@ func (p *Provider) getHTTPClient(ctx context.Context) (*http.Client, error) {
 			ClientID:     p.cfg.clientID,
 			ClientSecret: p.cfg.clientSecret,
 			TokenURL:     e.TokenURL,
-			AuthStyle:    e.AuthStyle,
+			AuthStyle:    oauth2.AuthStyleInParams,
 		}).TokenSource(tokenSourceCtx)
 	}
 


### PR DESCRIPTION
## Summary
Add a key cloak provider for directory data. I used the [admin API](https://www.keycloak.org/docs-api/latest/rest-api/index.html).

Querying group members isn't very efficient, but this seems to be how you have to do it. 

## Related issues
- [ENG-2073](https://linear.app/pomerium/issue/ENG-2073/support-directory-sync-with-keycloak)


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
