### PR TITLE
directory: avoid serving null

### DIFF
--- a/pkg/directory/http.go
+++ b/pkg/directory/http.go
@@ -43,6 +43,14 @@ func (h *handler) serve(ctx context.Context, w http.ResponseWriter, r *http.Requ
 		return fmt.Errorf("failed to get directory data: %w", err)
 	}
 
+	// don't serve null, but an empty array instead
+	if groups == nil {
+		groups = make([]Group, 0)
+	}
+	if users == nil {
+		users = make([]User, 0)
+	}
+
 	return httputil.ServeBundle(w, r, map[string]any{
 		GroupRecordType: groups,
 		UserRecordType:  users,


### PR DESCRIPTION
## Summary
For directory providers, with typical Go code, if there are no groups or users that would be typically be returned as `nil`:

```go
var groups []directory.Group
// groups = append(groups, ...)
```

Serialized as JSON you end up with `null`, but it would be better to serve this as `[]`.

## Related issues



## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
