### PR TITLE
ci: use latest golangci-lint, use .tool-versions, add update ci job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
 
-      - uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20
         with:
-          version: v1.64.8
-          args: --timeout=10m
+          version-file: .tool-versions

--- a/.github/workflows/release-tagged.yml
+++ b/.github/workflows/release-tagged.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c
         with:
-          go-version: 1.24.x
+          go-version-file: .tool-versions
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c
         with:
-          go-version: 1.24.x
+          go-version-file: .tool-versions
 
       - name: test
-        run: go test ./...
+        run: make test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - asasalint
     - asciicheck
@@ -12,14 +13,10 @@ linters:
     - errname
     - errorlint
     - exhaustive
-    # - gci # https://github.com/daixiang0/gci/issues/209
-    - gofumpt
     - goheader
-    - goimports
     - gomodguard
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - grouper
     - importas
@@ -27,7 +24,6 @@ linters:
     - makezero
     - misspell
     - nakedret
-    - nestif
     - nilerr
     - noctx
     - nolintlint
@@ -43,9 +39,22 @@ linters:
     - unused
     - usetesting
     - whitespace
-linters-settings:
-  gci:
-    custom-order: true
-    sections:
-      - standard # Standard section: captures all standard packages.
-      - default # Default section: contains all imports that could not be matched to another section type.
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+formatters:
+  enable:
+    - gci
+    - gofumpt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/pomerium)
+      custom-order: true

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+golangci-lint 2.7.2
+golang 1.25.5

--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,11 @@ snapshot: ## Create release snapshot
 .PHONY: lint
 lint:
 	@echo "@==> $@"
-	@VERSION=$$(go run github.com/mikefarah/yq/v4@v4.34.1 '.jobs.lint.steps[] | select(.uses == "golangci/golangci-lint-action*") | .with.version' .github/workflows/lint.yml) && \
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@$$VERSION run --fix ./...
+	golangci-lint run ./...
+
+.PHONY: generate
+generate:
+	@echo "==> $@"
 
 .PHONY: help
 help:

--- a/internal/bamboohr/employees_test.go
+++ b/internal/bamboohr/employees_test.go
@@ -46,7 +46,7 @@ func serveJSON(prefix, key string, statusCode int) func(w http.ResponseWriter, r
 		value := mux.Vars(r)[key]
 		if value == "" {
 			w.WriteHeader(http.StatusBadRequest)
-			_, _ = w.Write([]byte(fmt.Sprintf("expected %s in vars, got none", key)))
+			_, _ = fmt.Fprintf(w, "expected %s in vars, got none", key)
 			return
 		}
 		p := path.Join("testdata", fmt.Sprintf("%s-%s-%s.json", prefix, key, value))

--- a/internal/fleetdm/client/client.go
+++ b/internal/fleetdm/client/client.go
@@ -197,7 +197,7 @@ func (c *Client) newRequest(
 	}
 	u.RawQuery = query.Encode()
 
-	req, err := http.NewRequest(method, u.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}

--- a/internal/util/url.go
+++ b/internal/util/url.go
@@ -1,4 +1,4 @@
-package util
+package util //nolint
 
 import (
 	"encoding/json"

--- a/internal/zenefits/api.go
+++ b/internal/zenefits/api.go
@@ -41,7 +41,7 @@ type PeopleRequest struct {
 }
 
 func (req *PeopleRequest) getURL() string {
-	u := req.Auth.RequestURL("core/people")
+	u := req.RequestURL("core/people")
 
 	param := make(url.Values)
 	param.Set("includes", "department location")
@@ -95,7 +95,7 @@ type VacationRequest struct {
 const DateLayout = "2006-01-02"
 
 func (req *VacationRequest) getURL() string {
-	u := req.Auth.RequestURL("time_off/vacation_requests")
+	u := req.RequestURL("time_off/vacation_requests")
 
 	param := make(url.Values)
 	param.Set("includes", "person")

--- a/scripts/update-dependencies
+++ b/scripts/update-dependencies
@@ -1,0 +1,106 @@
+#!/bin/bash
+set -euo pipefail
+
+_project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/.."
+
+replace-in-file() {
+	local _search="${1?"search is required"}"
+	local _replace="${2?"replace is required"}"
+	local _file="${3?"file is required"}"
+	local _tmp
+
+	_tmp="$(mktemp)"
+	sed -E 's/'"$_search"'/'"$_replace"'/g' "$_file" >"$_tmp"
+	mv "$_tmp" "$_file"
+}
+
+require-command() {
+	local _command="${1?"command is required"}"
+
+	if ! command -v "$_command" >/dev/null 2>&1; then
+		echo "$_command is required"
+		exit 1
+	fi
+}
+
+get-tool-version() {
+	local _tool="${1?"tool is required"}"
+
+	require-command asdf
+
+	asdf current --no-header "$_tool" | tr -s ' ' | cut -d ' ' -f2
+}
+
+get-docker-tag-with-version() {
+	local _name="${1?"name is required"}"
+	local _tag="${2?"tag is required"}"
+
+	require-command docker
+	require-command jq
+
+	echo "$_tag@$(docker buildx imagetools inspect --format '{{json .}}' "$_name":"$_tag" | jq -r .manifest.digest)"
+}
+
+update-docker() {
+	pushd "$_project_root"
+
+	local _go_tag
+	_go_tag="$(get-docker-tag-with-version golang "$(get-tool-version golang)-bookworm")"
+
+	find . -type f -name "Dockerfile*" | while read _file; do
+		replace-in-file '^FROM golang:(.*) AS (.*)$' 'FROM golang:'"$_go_tag"' AS \2' "$_file"
+	done
+	find . -type f -name "*.dockerfile" | while read _file; do
+		replace-in-file '^FROM golang:(.*) AS (.*)$' 'FROM golang:'"$_go_tag"' AS \2' "$_file"
+	done
+
+	popd
+}
+
+update-pomerium() {
+	pushd "$_project_root"
+
+	require-command go
+
+	go get -u github.com/pomerium/datasource@main
+	go get -u github.com/pomerium/pomerium@main
+	go get -u github.com/pomerium/sdk-go@main
+	go get -u github.com/pomerium/webauthn@main
+	go mod tidy
+
+	popd
+}
+
+update-tools() {
+	pushd "$_project_root"
+
+	require-command asdf
+
+	asdf install golang latest:1.25
+	asdf set golang latest:1.25
+	asdf install golangci-lint latest:2
+	asdf set golangci-lint latest:2
+
+	popd
+}
+
+run() {
+	local _command="$1"
+	case "$_command" in
+	docker)
+		update-docker
+		;;
+	pomerium)
+		update-pomerium
+		;;
+	tools)
+		update-tools
+		;;
+	*)
+		echo "unknown command $_command"
+		exit 1
+		;;
+	esac
+}
+
+run "${1?'command is required'}"


### PR DESCRIPTION
## Summary
Use the latest golangci-lint, use .tool-versions, add update ci job.

## Related issues
- [ENG-3349](https://linear.app/pomerium/issue/ENG-3349/datasource-use-tool-versions-and-update-ci-task)


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
