### PR TITLE
ci: add a job that notifies dependencies when commits are made

### DIFF
--- a/.github/workflows/notify-dependencies.yaml
+++ b/.github/workflows/notify-dependencies.yaml
@@ -7,12 +7,12 @@ on:
     branches:
       - main
       - 0-[0-9]+-*
-      - cdoxsey/trigger-updates
 
 jobs:
   notify:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         repo:
           - enterprise-client

--- a/.github/workflows/notify-dependencies.yaml
+++ b/.github/workflows/notify-dependencies.yaml
@@ -20,6 +20,7 @@ jobs:
       - name: Notify
         uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26
         with:
+          ref: main
           repo: ${{ matrix.repository }}
           token: ${{ secrets.APPARITOR_GITHUB_TOKEN }}
           workflow: update-dependencies.yaml

--- a/.github/workflows/notify-dependencies.yaml
+++ b/.github/workflows/notify-dependencies.yaml
@@ -20,7 +20,6 @@ jobs:
       - name: Notify
         uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26
         with:
-          inputs: '{"branch":"${{ github.ref_name }}"}'
           repo: ${{ matrix.repository }}
           token: ${{ secrets.APPARITOR_GITHUB_TOKEN }}
-          workflow: update-branch-dependencies.yaml
+          workflow: update-dependencies.yaml

--- a/.github/workflows/notify-dependencies.yaml
+++ b/.github/workflows/notify-dependencies.yaml
@@ -1,0 +1,26 @@
+name: Notify Dependencies
+
+permissions: {}
+
+on:
+  push:
+    branches:
+      - main
+      - 0-[0-9]+-*
+      - cdoxsey/trigger-updates
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repository:
+          - pomerium/enterprise-client-go
+    steps:
+      - name: Notify
+        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26
+        with:
+          inputs: '{"branch":"${{ github.ref_name }}"}'
+          repo: ${{ matrix.repository }}
+          token: ${{ secrets.APPARITOR_GITHUB_TOKEN }}
+          workflow: update-branch-dependencies.yaml

--- a/.github/workflows/notify-dependencies.yaml
+++ b/.github/workflows/notify-dependencies.yaml
@@ -14,14 +14,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        repository:
-          - pomerium/enterprise-client-go
+        repo:
+          - enterprise-client
+          - enterprise-client-go
+          - pomerium
+          - pomerium-console
     steps:
       - name: Notify
         uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26
         with:
           ref: main
-          repo: ${{ matrix.repository }}
+          repo: pomerium/${{ matrix.repo }}
           sync-status: true
           token: ${{ secrets.APPARITOR_GITHUB_TOKEN }}
           wait-for-completion: true

--- a/.github/workflows/notify-dependencies.yaml
+++ b/.github/workflows/notify-dependencies.yaml
@@ -22,5 +22,7 @@ jobs:
         with:
           ref: main
           repo: ${{ matrix.repository }}
+          sync-status: true
           token: ${{ secrets.APPARITOR_GITHUB_TOKEN }}
+          wait-for-completion: true
           workflow: update-dependencies.yaml


### PR DESCRIPTION
## Summary
When a commit is made to main or a release branch we should notify other repositories that an update was made.

## Related issues
For [ENG-4257](https://linear.app/pomerium/issue/ENG-4257/various-trigger-update-dependency-jobs-on-push)


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
