### PR TITLE
feat(github): support using node ids for user and group ids

### DIFF
--- a/cmd/pomerium-datasource/directory.go
+++ b/cmd/pomerium-datasource/directory.go
@@ -81,10 +81,12 @@ func directoryCommand(logger zerolog.Logger) *cobra.Command {
 			func(flags *pflag.FlagSet) func() directory.Provider {
 				personalAccessToken := requiredStringFlag(flags, "personal-access-token", "personal access token")
 				username := requiredStringFlag(flags, "username", "username")
+				useNodeIDs := optionalBoolFlag(flags, "use-node-ids", "use node ids instead of logins for ids")
 				return func() directory.Provider {
 					return github.New(
 						github.WithLogger(logger),
 						github.WithPersonalAccessToken(*personalAccessToken),
+						github.WithUseNodeIDs(*useNodeIDs),
 						github.WithUsername(*username),
 					)
 				}
@@ -226,6 +228,12 @@ func directoryUploadSubCommand(
 	}
 
 	return cmd
+}
+
+func optionalBoolFlag(flags *pflag.FlagSet, name, usage string) *bool {
+	ptr := new(bool)
+	flags.BoolVar(ptr, name, false, usage)
+	return ptr
 }
 
 func optionalBytesFlag(flags *pflag.FlagSet, name, usage string) *[]byte {

--- a/pkg/directory/github/config.go
+++ b/pkg/directory/github/config.go
@@ -20,23 +20,24 @@ type config struct {
 	logger              zerolog.Logger
 	personalAccessToken string
 	url                 *url.URL
+	useNodeIDs          bool
 	username            string
 }
 
 // An Option updates the github configuration.
 type Option func(cfg *config)
 
-// WithLogger sets the logger in the config.
-func WithLogger(logger zerolog.Logger) Option {
-	return func(cfg *config) {
-		cfg.logger = logger
-	}
-}
-
 // WithHTTPClient sets the http client option.
 func WithHTTPClient(httpClient *http.Client) Option {
 	return func(cfg *config) {
 		cfg.httpClient = httpClient
+	}
+}
+
+// WithLogger sets the logger in the config.
+func WithLogger(logger zerolog.Logger) Option {
+	return func(cfg *config) {
+		cfg.logger = logger
 	}
 }
 
@@ -54,6 +55,13 @@ func WithURL(u *url.URL) Option {
 	}
 }
 
+// WithUseNodeIDs sets the use-node-id option in the config.
+func WithUseNodeIDs(useNodeIDs bool) Option {
+	return func(cfg *config) {
+		cfg.useNodeIDs = useNodeIDs
+	}
+}
+
 // WithUsername sets the username in the config.
 func WithUsername(username string) Option {
 	return func(cfg *config) {
@@ -65,6 +73,7 @@ func getConfig(options ...Option) *config {
 	cfg := new(config)
 	WithHTTPClient(http.DefaultClient)(cfg)
 	WithLogger(log.Logger)(cfg)
+	WithUseNodeIDs(false)(cfg)
 	WithURL(defaultURL)(cfg)
 	for _, option := range options {
 		option(cfg)

--- a/pkg/directory/github/github.go
+++ b/pkg/directory/github/github.go
@@ -3,7 +3,8 @@ package github
 
 // see: https://docs.github.com/en/free-pro-team@latest/rest/reference/users#get-a-user
 type apiUserObject struct {
-	Login string `json:"login"`
-	Name  string `json:"name"`
-	Email string `json:"email"`
+	NodeID string `json:"node_id"`
+	Login  string `json:"login"`
+	Name   string `json:"name"`
+	Email  string `json:"email"`
 }

--- a/pkg/directory/github/github_test.go
+++ b/pkg/directory/github/github_test.go
@@ -66,13 +66,13 @@ func newMockAPI(t *testing.T, _ *httptest.Server) http.Handler {
 				case "org1":
 					membersWithRole.PageInfo = qlPageInfo{EndCursor: "TOKEN1", HasNextPage: true}
 					membersWithRole.Nodes = []qlUser{
-						{ID: "user1", Login: "user1", Name: "User 1", Email: "user1@example.com"},
-						{ID: "user2", Login: "user2", Name: "User 2", Email: "user2@example.com"},
+						{NodeID: "nodeid-user1", Login: "user1", Name: "User 1", Email: "user1@example.com"},
+						{NodeID: "nodeid-user2", Login: "user2", Name: "User 2", Email: "user2@example.com"},
 					}
 				case "org2":
 					membersWithRole.PageInfo = qlPageInfo{HasNextPage: false}
 					membersWithRole.Nodes = []qlUser{
-						{ID: "user4", Login: "user4", Name: "User 4", Email: "user4@example.com"},
+						{NodeID: "nodeid-user4", Login: "user4", Name: "User 4", Email: "user4@example.com"},
 					}
 				default:
 					t.Errorf("unexpected org slug: %s", orgSlug)
@@ -80,7 +80,7 @@ func newMockAPI(t *testing.T, _ *httptest.Server) http.Handler {
 			case `TOKEN1`:
 				membersWithRole.PageInfo = qlPageInfo{HasNextPage: false}
 				membersWithRole.Nodes = []qlUser{
-					{ID: "user3", Login: "user3", Name: "User 3", Email: "user3@example.com"},
+					{NodeID: "nodeid-user3", Login: "user3", Name: "User 3", Email: "user3@example.com"},
 				}
 			default:
 				t.Errorf("unexpected cursor: %s", cursor)
@@ -96,7 +96,7 @@ func newMockAPI(t *testing.T, _ *httptest.Server) http.Handler {
 			switch teamSlug {
 			case "team3":
 				result.Data.Organization.Team.Members.Edges = []qlTeamMemberEdge{
-					{Node: qlUser{ID: "user3"}},
+					{Node: qlUser{NodeID: "nodeid-user3"}},
 				}
 			}
 		}
@@ -163,14 +163,14 @@ func newMockAPI(t *testing.T, _ *httptest.Server) http.Handler {
 					teams.PageInfo = qlPageInfo{HasNextPage: true, EndCursor: "TOKEN1"}
 					teams.Edges = []qlTeamEdge{
 						{Node: qlTeam{
-							ID:   renderNodeField(field, []string{"edges", "node", "id"}, "MDQ6VGVhbTE="),
-							Slug: renderNodeField(field, []string{"edges", "node", "slug"}, "team1"),
-							Name: renderNodeField(field, []string{"edges", "node", "name"}, "Team 1"),
+							NodeID: renderNodeField(field, []string{"edges", "node", "id"}, "nodeid-team1"),
+							Slug:   renderNodeField(field, []string{"edges", "node", "slug"}, "team1"),
+							Name:   renderNodeField(field, []string{"edges", "node", "name"}, "Team 1"),
 							Members: &qlTeamMemberConnection{
 								PageInfo: qlPageInfo{HasNextPage: false},
 								Edges: []qlTeamMemberEdge{
-									{Node: qlUser{ID: "user1"}},
-									{Node: qlUser{ID: "user2"}},
+									{Node: qlUser{NodeID: "nodeid-user1", Login: "user1"}},
+									{Node: qlUser{NodeID: "nodeid-user2", Login: "user2"}},
 								},
 							},
 						}},
@@ -179,14 +179,14 @@ func newMockAPI(t *testing.T, _ *httptest.Server) http.Handler {
 					teams.PageInfo = qlPageInfo{HasNextPage: false}
 					teams.Edges = []qlTeamEdge{
 						{Node: qlTeam{
-							ID:   renderNodeField(field, []string{"edges", "node", "id"}, "MDQ6VGVhbTM="),
-							Slug: renderNodeField(field, []string{"edges", "node", "slug"}, "team3"),
-							Name: renderNodeField(field, []string{"edges", "node", "name"}, "Team 3"),
+							NodeID: renderNodeField(field, []string{"edges", "node", "id"}, "nodeid-team3"),
+							Slug:   renderNodeField(field, []string{"edges", "node", "slug"}, "team3"),
+							Name:   renderNodeField(field, []string{"edges", "node", "name"}, "Team 3"),
 							Members: &qlTeamMemberConnection{
 								PageInfo: qlPageInfo{HasNextPage: true, EndCursor: "TOKEN1"},
 								Edges: []qlTeamMemberEdge{
-									{Node: qlUser{ID: "user1"}},
-									{Node: qlUser{ID: "user2"}},
+									{Node: qlUser{NodeID: "nodeid-user1", Login: "user1"}},
+									{Node: qlUser{NodeID: "nodeid-user2", Login: "user2"}},
 								},
 							},
 						}},
@@ -194,13 +194,13 @@ func newMockAPI(t *testing.T, _ *httptest.Server) http.Handler {
 					if userLogin == "" || userLogin == "user4" {
 						teams.Edges = append(teams.Edges, qlTeamEdge{
 							Node: qlTeam{
-								ID:   renderNodeField(field, []string{"edges", "node", "id"}, "MDQ6VGVhbTQ="),
-								Slug: renderNodeField(field, []string{"edges", "node", "slug"}, "team4"),
-								Name: renderNodeField(field, []string{"edges", "node", "name"}, "Team 4"),
+								NodeID: renderNodeField(field, []string{"edges", "node", "id"}, "nodeid-team4"),
+								Slug:   renderNodeField(field, []string{"edges", "node", "slug"}, "team4"),
+								Name:   renderNodeField(field, []string{"edges", "node", "name"}, "Team 4"),
 								Members: &qlTeamMemberConnection{
 									PageInfo: qlPageInfo{HasNextPage: false},
 									Edges: []qlTeamMemberEdge{
-										{Node: qlUser{ID: "user4"}},
+										{Node: qlUser{NodeID: "nodeid-user4", Login: "user4"}},
 									},
 								},
 							},
@@ -213,13 +213,13 @@ func newMockAPI(t *testing.T, _ *httptest.Server) http.Handler {
 				teams.PageInfo = qlPageInfo{HasNextPage: false}
 				teams.Edges = []qlTeamEdge{
 					{Node: qlTeam{
-						ID:   renderNodeField(field, []string{"edges", "node", "id"}, "MDQ6VGVhbTI="),
-						Slug: renderNodeField(field, []string{"edges", "node", "slug"}, "team2"),
-						Name: renderNodeField(field, []string{"edges", "node", "name"}, "Team 2"),
+						NodeID: renderNodeField(field, []string{"edges", "node", "id"}, "nodeid-team2"),
+						Slug:   renderNodeField(field, []string{"edges", "node", "slug"}, "team2"),
+						Name:   renderNodeField(field, []string{"edges", "node", "name"}, "Team 2"),
 						Members: &qlTeamMemberConnection{
 							PageInfo: qlPageInfo{HasNextPage: false},
 							Edges: []qlTeamMemberEdge{
-								{Node: qlUser{ID: "user1"}},
+								{Node: qlUser{NodeID: "nodeid-user1", Login: "user1"}},
 							},
 						},
 					}},
@@ -280,12 +280,12 @@ func newMockAPI(t *testing.T, _ *httptest.Server) http.Handler {
 	r.Get("/orgs/{org_id}/teams", func(w http.ResponseWriter, r *http.Request) {
 		teams := map[string][]M{
 			"org1": {
-				{"slug": "team1", "id": 1},
-				{"slug": "team2", "id": 2},
+				{"slug": "team1", "id": 1, "node_id": "nodeid-team1"},
+				{"slug": "team2", "id": 2, "node_id": "nodeid-team2"},
 			},
 			"org2": {
-				{"slug": "team3", "id": 3},
-				{"slug": "team4", "id": 4},
+				{"slug": "team3", "id": 3, "node_id": "nodeid-team3"},
+				{"slug": "team4", "id": 4, "node_id": "nodeid-team4"},
 			},
 		}
 		orgID := chi.URLParam(r, "org_id")
@@ -295,21 +295,21 @@ func newMockAPI(t *testing.T, _ *httptest.Server) http.Handler {
 		members := map[string]map[string][]M{
 			"org1": {
 				"team1": {
-					{"login": "user1"},
-					{"login": "user2"},
+					{"id": "nodeid-user1", "login": "user1"},
+					{"id": "nodeid-user2", "login": "user2"},
 				},
 				"team2": {
-					{"login": "user1"},
+					{"id": "nodeid-user1", "login": "user1"},
 				},
 			},
 			"org2": {
 				"team3": {
-					{"login": "user1"},
-					{"login": "user2"},
-					{"login": "user3"},
+					{"id": "nodeid-user1", "login": "user1"},
+					{"id": "nodeid-user2", "login": "user2"},
+					{"id": "nodeid-user3", "login": "user3"},
 				},
 				"team4": {
-					{"login": "user4"},
+					{"id": "nodeid-user4", "login": "user4"},
 				},
 			},
 		}
@@ -319,10 +319,10 @@ func newMockAPI(t *testing.T, _ *httptest.Server) http.Handler {
 	})
 	r.Get("/users/{user_id}", func(w http.ResponseWriter, r *http.Request) {
 		users := map[string]apiUserObject{
-			"user1": {Login: "user1", Name: "User 1", Email: "user1@example.com"},
-			"user2": {Login: "user2", Name: "User 2", Email: "user2@example.com"},
-			"user3": {Login: "user3", Name: "User 3", Email: "user3@example.com"},
-			"user4": {Login: "user4", Name: "User 4", Email: "user4@example.com"},
+			"user1": {NodeID: "nodeid-user1", Login: "user1", Name: "User 1", Email: "user1@example.com"},
+			"user2": {NodeID: "nodeid-user2", Login: "user2", Name: "User 2", Email: "user2@example.com"},
+			"user3": {NodeID: "nodeid-user3", Login: "user3", Name: "User 3", Email: "user3@example.com"},
+			"user4": {NodeID: "nodeid-user4", Login: "user4", Name: "User 4", Email: "user4@example.com"},
 		}
 		userID := chi.URLParam(r, "user_id")
 		_ = json.NewEncoder(w).Encode(users[userID])
@@ -337,28 +337,106 @@ func TestProvider_GetDirectory(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mockAPI.ServeHTTP(w, r)
 	}))
-	defer srv.Close()
+	t.Cleanup(srv.Close)
 	mockAPI = newMockAPI(t, srv)
 
-	p := New(
-		WithPersonalAccessToken("xyz"),
-		WithURL(mustParseURL(srv.URL)),
-		WithUsername("abc"),
-	)
-	groups, users, err := p.GetDirectory(t.Context())
-	assert.NoError(t, err)
-	assert.Equal(t, []directory.Group{
-		{ID: "team1", Name: "team1"},
-		{ID: "team2", Name: "team2"},
-		{ID: "team3", Name: "team3"},
-		{ID: "team4", Name: "team4"},
-	}, groups)
-	assert.Equal(t, []directory.User{
-		{ID: "user1", GroupIDs: []string{"team1", "team2", "team3"}, DisplayName: "User 1", Email: "user1@example.com"},
-		{ID: "user2", GroupIDs: []string{"team1", "team3"}, DisplayName: "User 2", Email: "user2@example.com"},
-		{ID: "user3", GroupIDs: []string{"team3"}, DisplayName: "User 3", Email: "user3@example.com"},
-		{ID: "user4", GroupIDs: []string{"team4"}, DisplayName: "User 4", Email: "user4@example.com"},
-	}, users)
+	t.Run("logins", func(t *testing.T) {
+		t.Parallel()
+		p := New(
+			WithPersonalAccessToken("xyz"),
+			WithURL(mustParseURL(srv.URL)),
+			WithUsername("abc"),
+		)
+		groups, users, err := p.GetDirectory(t.Context())
+		assert.NoError(t, err)
+		assert.Equal(t, []directory.Group{
+			{ID: "team1", Name: "team1"},
+			{ID: "team2", Name: "team2"},
+			{ID: "team3", Name: "team3"},
+			{ID: "team4", Name: "team4"},
+		}, groups)
+		assert.Equal(t, []directory.User{
+			{
+				ID:          "user1",
+				GroupIDs:    []string{"team1", "team2", "team3"},
+				DisplayName: "User 1",
+				Email:       "user1@example.com",
+			},
+			{
+				ID:          "user2",
+				GroupIDs:    []string{"team1", "team3"},
+				DisplayName: "User 2",
+				Email:       "user2@example.com",
+			},
+			{
+				ID:          "user3",
+				GroupIDs:    []string{"team3"},
+				DisplayName: "User 3",
+				Email:       "user3@example.com",
+			},
+			{
+				ID:          "user4",
+				GroupIDs:    []string{"team4"},
+				DisplayName: "User 4",
+				Email:       "user4@example.com",
+			},
+		}, users)
+	})
+	t.Run("node ids", func(t *testing.T) {
+		t.Parallel()
+		p := New(
+			WithPersonalAccessToken("xyz"),
+			WithURL(mustParseURL(srv.URL)),
+			WithUseNodeIDs(true),
+			WithUsername("abc"),
+		)
+		groups, users, err := p.GetDirectory(t.Context())
+		assert.NoError(t, err)
+		assert.Equal(t, []directory.Group{
+			{
+				ID:   "nodeid-team1",
+				Name: "team1",
+			},
+			{
+				ID:   "nodeid-team2",
+				Name: "team2",
+			},
+			{
+				ID:   "nodeid-team3",
+				Name: "team3",
+			},
+			{
+				ID:   "nodeid-team4",
+				Name: "team4",
+			},
+		}, groups)
+		assert.Equal(t, []directory.User{
+			{
+				ID:          "nodeid-user1",
+				GroupIDs:    []string{"nodeid-team1", "nodeid-team2", "nodeid-team3"},
+				DisplayName: "User 1",
+				Email:       "user1@example.com",
+			},
+			{
+				ID:          "nodeid-user2",
+				GroupIDs:    []string{"nodeid-team1", "nodeid-team3"},
+				DisplayName: "User 2",
+				Email:       "user2@example.com",
+			},
+			{
+				ID:          "nodeid-user3",
+				GroupIDs:    []string{"nodeid-team3"},
+				DisplayName: "User 3",
+				Email:       "user3@example.com",
+			},
+			{
+				ID:          "nodeid-user4",
+				GroupIDs:    []string{"nodeid-team4"},
+				DisplayName: "User 4",
+				Email:       "user4@example.com",
+			},
+		}, users)
+	})
 }
 
 func mustParseURL(rawurl string) *url.URL {

--- a/pkg/directory/github/graphql.go
+++ b/pkg/directory/github/graphql.go
@@ -29,7 +29,7 @@ type (
 		Data *qlData `json:"data"`
 	}
 	qlTeam struct {
-		ID      string                  `json:"id"`
+		NodeID  string                  `json:"id"`
 		Name    string                  `json:"name"`
 		Slug    string                  `json:"slug"`
 		Members *qlTeamMemberConnection `json:"members"`
@@ -49,16 +49,16 @@ type (
 		Node qlUser `json:"node"`
 	}
 	qlUser struct {
-		ID    string `json:"id"`
-		Login string `json:"login"`
-		Name  string `json:"name"`
-		Email string `json:"email"`
+		NodeID string `json:"id"`
+		Login  string `json:"login"`
+		Name   string `json:"name"`
+		Email  string `json:"email"`
 	}
 	teamWithMemberIDs struct {
-		ID        string
-		Slug      string
-		Name      string
-		MemberIDs []string
+		NodeID        string
+		Slug          string
+		Name          string
+		MemberNodeIDs []string
 	}
 )
 
@@ -152,15 +152,15 @@ func (p *Provider) listOrganizationTeamsWithMemberIDs(ctx context.Context, orgSl
 		}
 
 		for _, teamEdge := range res.Data.Organization.Teams.Edges {
-			var memberIDs []string
+			var memberNodeIDs []string
 			for _, memberEdge := range teamEdge.Node.Members.Edges {
-				memberIDs = append(memberIDs, memberEdge.Node.ID)
+				memberNodeIDs = append(memberNodeIDs, memberEdge.Node.NodeID)
 			}
 			results = append(results, teamWithMemberIDs{
-				ID:        teamEdge.Node.ID,
-				Slug:      teamEdge.Node.Slug,
-				Name:      teamEdge.Node.Name,
-				MemberIDs: memberIDs,
+				NodeID:        teamEdge.Node.NodeID,
+				Slug:          teamEdge.Node.Slug,
+				Name:          teamEdge.Node.Name,
+				MemberNodeIDs: memberNodeIDs,
 			})
 			pageInfos = append(pageInfos, teamEdge.Node.Members.PageInfo)
 		}
@@ -174,8 +174,6 @@ func (p *Provider) listOrganizationTeamsWithMemberIDs(ctx context.Context, orgSl
 	// it's possible we didn't get all the members if the initial query, so go through each team and
 	// check the member pageInfo. If there are still remaining members, query those.
 	for i, pageInfo := range pageInfos {
-		i, pageInfo := i, pageInfo
-
 		if !pageInfo.HasNextPage {
 			continue
 		}
@@ -206,7 +204,7 @@ func (p *Provider) listOrganizationTeamsWithMemberIDs(ctx context.Context, orgSl
 			}
 
 			for _, memberEdge := range res.Data.Organization.Team.Members.Edges {
-				results[i].MemberIDs = append(results[i].MemberIDs, memberEdge.Node.ID)
+				results[i].MemberNodeIDs = append(results[i].MemberNodeIDs, memberEdge.Node.NodeID)
 			}
 
 			if !res.Data.Organization.Team.Members.PageInfo.HasNextPage {
@@ -219,7 +217,7 @@ func (p *Provider) listOrganizationTeamsWithMemberIDs(ctx context.Context, orgSl
 	return results, nil
 }
 
-func encode(obj interface{}) string {
+func encode(obj any) string {
 	bs, _ := json.Marshal(obj)
 	return string(bs)
 }

--- a/pkg/directory/github/provider.go
+++ b/pkg/directory/github/provider.go
@@ -5,9 +5,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/url"
+	"slices"
 	"sort"
+	"strings"
 
 	"github.com/tomnomnom/linkheader"
 
@@ -33,9 +36,9 @@ func (p *Provider) GetDirectory(ctx context.Context) ([]directory.Group, []direc
 		return nil, nil, err
 	}
 
-	userLoginToGroups := map[string][]string{}
+	userNodeIDToGroups := map[string][]string{}
 
-	var allGroups []directory.Group
+	groupLookup := map[string]directory.Group{}
 	for _, orgSlug := range orgSlugs {
 		teams, err := p.listOrganizationTeamsWithMemberIDs(ctx, orgSlug)
 		if err != nil {
@@ -43,20 +46,22 @@ func (p *Provider) GetDirectory(ctx context.Context) ([]directory.Group, []direc
 		}
 
 		for _, team := range teams {
-			allGroups = append(allGroups, directory.Group{
-				ID:   team.Slug,
+			dg := directory.Group{
 				Name: team.Slug,
-			})
-			for _, memberID := range team.MemberIDs {
-				userLoginToGroups[memberID] = append(userLoginToGroups[memberID], team.Slug)
+			}
+			if p.cfg.useNodeIDs {
+				dg.ID = team.NodeID
+			} else {
+				dg.ID = team.Slug
+			}
+			groupLookup[dg.ID] = dg
+			for _, memberNodeID := range team.MemberNodeIDs {
+				userNodeIDToGroups[memberNodeID] = append(userNodeIDToGroups[memberNodeID], dg.ID)
 			}
 		}
 	}
-	sort.Slice(allGroups, func(i, j int) bool {
-		return allGroups[i].ID < allGroups[j].ID
-	})
 
-	var allUsers []directory.User
+	userLookup := map[string]directory.User{}
 	for _, orgSlug := range orgSlugs {
 		members, err := p.listOrganizationMembers(ctx, orgSlug)
 		if err != nil {
@@ -65,17 +70,25 @@ func (p *Provider) GetDirectory(ctx context.Context) ([]directory.Group, []direc
 
 		for _, member := range members {
 			du := directory.User{
-				ID:          member.Login,
-				GroupIDs:    userLoginToGroups[member.ID],
+				GroupIDs:    userNodeIDToGroups[member.NodeID],
 				DisplayName: member.Name,
 				Email:       member.Email,
 			}
+			if p.cfg.useNodeIDs {
+				du.ID = member.NodeID
+			} else {
+				du.ID = member.Login
+			}
 			sort.Strings(du.GroupIDs)
-			allUsers = append(allUsers, du)
+			userLookup[du.ID] = du
 		}
 	}
-	sort.Slice(allUsers, func(i, j int) bool {
-		return allUsers[i].ID < allUsers[j].ID
+
+	allGroups := slices.SortedFunc(maps.Values(groupLookup), func(dg1, dg2 directory.Group) int {
+		return strings.Compare(dg1.ID, dg2.ID)
+	})
+	allUsers := slices.SortedFunc(maps.Values(userLookup), func(du1, du2 directory.User) int {
+		return strings.Compare(du1.ID, du2.ID)
 	})
 
 	return allGroups, allUsers, nil
@@ -105,7 +118,7 @@ func (p *Provider) listOrgs(ctx context.Context) (orgSlugs []string, err error) 
 	return orgSlugs, nil
 }
 
-func (p *Provider) api(ctx context.Context, apiURL string, out interface{}) (http.Header, error) {
+func (p *Provider) api(ctx context.Context, apiURL string, out any) (http.Header, error) {
 	username := p.cfg.username
 	if username == "" {
 		return nil, ErrUsernameRequired
@@ -141,7 +154,7 @@ func (p *Provider) api(ctx context.Context, apiURL string, out interface{}) (htt
 	return res.Header, nil
 }
 
-func (p *Provider) graphql(ctx context.Context, query string, out interface{}) (http.Header, error) {
+func (p *Provider) graphql(ctx context.Context, query string, out any) (http.Header, error) {
 	username := p.cfg.username
 	if username == "" {
 		return nil, ErrUsernameRequired


### PR DESCRIPTION
## Summary
Instead of using GitHub logins (like `calebdoxsey`) and GitHub team slugs use GitHub node ids (like `MDQ6VXNlcjM5NTI3Mg==`). The GitHub node id is the `id` in GraphQL and is a unique identifier for a user that is immutable and cannot be reused or reassigned.

This option can be turned on with `WithUseNodeIDs` and the existing behavior is the default.

## Related issues
- [ENG-4267](https://linear.app/pomerium/issue/ENG-4267/datasourcegithub-use-github-node-id-as-user-id)

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
